### PR TITLE
Fix topic filter matching

### DIFF
--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -847,11 +847,12 @@ class Broker:
         else:
             # else use regex
             match_pattern = re.compile(
-                a_filter.replace("#", ".*")
-                .replace("$", "\$")
-                .replace("+", "[/\$\s\w\d]+")
+                re.escape(a_filter)
+                .replace("\\#", "?.*")
+                .replace("\\+", "[^/]*")
+                .lstrip("?")
             )
-            return match_pattern.match(topic)
+            return match_pattern.fullmatch(topic)
 
     async def _broadcast_loop(self):
         running_tasks = deque()


### PR DESCRIPTION
- re.escape() the whole filter string first to escape _all_ regex
  metacharacters in it, not just $. (# and + are both regex metacharacters,
  so their replace expressions now need a leading \\ to replace the
  escaping, too.)
- `#` matches topics both with and without a trailing /, so the replace
  expressions adds a '?' before the '.*'. The .lstrip('?') at the end removes
  this in case the # was the first character in the filter.
- `+` should only match a single level, but it should _also_ match empty levels,
  so use '[^/]*' to replace it.
- Use Regex.fullmatch() to match against the whole topic string, not just
  its start.

Also add two unit tests to test this matching, and fix an incorrect match
against + in test_client_subscribe_publish_dollar_topic_2.