### PR TITLE
Permit connect() and reconnect() coroutines to be cancelled

### DIFF
--- a/hbmqtt/client.py
+++ b/hbmqtt/client.py
@@ -145,6 +145,8 @@ class MQTTClient:
 
         try:
             return (await self._do_connect())
+        except asyncio.CancelledError:
+            raise
         except BaseException as be:
             self.logger.warning("Connection failed: %r" % be)
             auto_reconnect = self.config.get('auto_reconnect', False)
@@ -213,6 +215,8 @@ class MQTTClient:
             try:
                 self.logger.debug("Reconnect attempt %d ..." % nb_attempt)
                 return (await self._do_connect())
+            except asyncio.CancelledError:
+                raise
             except BaseException as e:
                 self.logger.warning("Reconnection attempt failed: %r" % e)
                 if reconnect_retries >= 0 and nb_attempt > reconnect_retries:


### PR DESCRIPTION
The plain `except BaseException` statement used in the two coroutines
also matches asyncio.CancelledError and thus prevents them from
being cancelled. Prepend a simple re-raising except block for
asyncio.CancelledError to get them to work with task cancellation.