### PR TITLE
Make WebSockets work with IPv6 addresses

### DIFF
--- a/hbmqtt/adapters.py
+++ b/hbmqtt/adapters.py
@@ -115,7 +115,10 @@ class WebSocketsWriter(WriterAdapter):
         self._stream = io.BytesIO(b'')
 
     def get_peer_info(self):
-        return self._protocol.remote_address
+        # remote_address can be either a 4-tuple or 2-tuple depending on whether
+        # it is an IPv6 or IPv4 address, so we take their shared (host, port)
+        # prefix here to present a uniform return value.
+        return self._protocol.remote_address[:2]
 
     async def close(self):
         await self._protocol.close()


### PR DESCRIPTION
WebSocketsWriter.get_peer_info() naively returns just
self._protocol.remote_address, but this is a 4-tuple in IPv6,
which will raise ValueErrors when client code tries to unpack
it into two elements. Fortunately the first two elements of the
tuple are the same as in IPv4 and should be all that we need
(get_peer_info() is currently only used for logging), so just
return a 2-prefix of the value instead.