### PR TITLE
inherit BrokerException from Exception

### DIFF
--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -43,7 +43,7 @@ EVENT_BROKER_CLIENT_UNSUBSCRIBED = "broker_client_unsubscribed"
 EVENT_BROKER_MESSAGE_RECEIVED = "broker_message_received"
 
 
-class BrokerException(BaseException):
+class BrokerException(Exception):
     pass
 
 


### PR DESCRIPTION
AFAIK user defined exceptions should not inherit from `BaseException` unless there is a really good reason to do that.