### PR TITLE
catch Exceptions instead of BaseExceptions

### DIFF
--- a/amqtt/client.py
+++ b/amqtt/client.py
@@ -165,8 +165,8 @@ class MQTTClient:
             return await self._do_connect()
         except asyncio.CancelledError:
             raise
-        except BaseException as be:
-            self.logger.warning("Connection failed: %r" % be)
+        except Exception as e:
+            self.logger.warning("Connection failed: %r" % e)
             auto_reconnect = self.config.get("auto_reconnect", False)
             if not auto_reconnect:
                 raise
@@ -237,13 +237,13 @@ class MQTTClient:
                 return await self._do_connect()
             except asyncio.CancelledError:
                 raise
-            except BaseException as e:
+            except Exception as e:
                 self.logger.warning("Reconnection attempt failed: %r" % e)
                 if reconnect_retries >= 0 and nb_attempt > reconnect_retries:
                     self.logger.error(
                         "Maximum number of connection attempts reached. Reconnection aborted"
                     )
-                    raise ConnectException("Too many connection attempts failed")
+                    raise ConnectException("Too many connection attempts failed") from e
                 exp = 2 ** nb_attempt
                 delay = exp if exp < reconnect_max_interval else reconnect_max_interval
                 self.logger.debug("Waiting %d second before next attempt" % delay)

--- a/amqtt/mqtt/protocol/client_handler.py
+++ b/amqtt/mqtt/protocol/client_handler.py
@@ -39,7 +39,8 @@ class ClientProtocolHandler(ProtocolHandler):
             try:
                 self.logger.debug("Cancel ping task")
                 self._ping_task.cancel()
-            except BaseException:
+            except Exception as e:
+                self.logger.debug("Silenced exception %r", e)
                 pass
         if not self._disconnect_waiter.done():
             self._disconnect_waiter.cancel()
@@ -90,8 +91,8 @@ class ClientProtocolHandler(ProtocolHandler):
             if not self._ping_task:
                 self.logger.debug("Scheduling Ping")
                 self._ping_task = asyncio.ensure_future(self.mqtt_ping())
-        except BaseException as be:
-            self.logger.debug("Exception ignored in ping task: %r" % be)
+        except Exception as e:
+            self.logger.debug("Exception ignored in ping task: %r" % e)
 
     def handle_read_timeout(self):
         pass

--- a/amqtt/mqtt/protocol/client_handler.py
+++ b/amqtt/mqtt/protocol/client_handler.py
@@ -35,13 +35,10 @@ class ClientProtocolHandler(ProtocolHandler):
 
     async def stop(self):
         await super().stop()
-        if self._ping_task:
-            try:
-                self.logger.debug("Cancel ping task")
-                self._ping_task.cancel()
-            except Exception as e:
-                self.logger.debug("Silenced exception %r", e)
-                pass
+        if self._ping_task and not self._ping_task.cancelled():
+            self.logger.debug("Cancel ping task")
+            self._ping_task.cancel()
+
         if not self._disconnect_waiter.done():
             self._disconnect_waiter.cancel()
         self._disconnect_waiter = None

--- a/amqtt/mqtt/protocol/handler.py
+++ b/amqtt/mqtt/protocol/handler.py
@@ -59,7 +59,7 @@ EVENT_MQTT_PACKET_SENT = "mqtt_packet_sent"
 EVENT_MQTT_PACKET_RECEIVED = "mqtt_packet_received"
 
 
-class ProtocolHandlerException(BaseException):
+class ProtocolHandlerException(Exception):
     pass
 
 
@@ -524,7 +524,7 @@ class ProtocolHandler:
                 self.handle_read_timeout()
             except NoDataException:
                 self.logger.debug("%s No data available" % self.session.client_id)
-            except BaseException as e:
+            except Exception as e:
                 self.logger.warning(
                     "%s Unhandled exception in reader coro: %r"
                     % (type(self).__name__, e)
@@ -554,7 +554,7 @@ class ProtocolHandler:
             await self.handle_connection_closed()
         except asyncio.CancelledError:
             raise
-        except BaseException as e:
+        except Exception as e:
             self.logger.warning("Unhandled exception: %s" % e)
             raise
 


### PR DESCRIPTION
Took another look at exception handling (after discussing https://github.com/Yakifo/amqtt/issues/51) and found more usage of `BaseException` handling which is discouraged. Do you see a good reason to handle `BaseException`s @FlorianLudwig?
Comments @volkerjaenisch?