### PR TITLE
Hbmqtt transition

### DIFF
--- a/amqtt/scripts/broker_script.py
+++ b/amqtt/scripts/broker_script.py
@@ -2,7 +2,7 @@
 #
 # See the file license.txt for copying permission.
 """
-HBMQTT - MQTT 3.1.1 broker
+aMQTT - MQTT 3.1.1 broker
 
 Usage:
     hbmqtt --version

--- a/gen_transition_code.py
+++ b/gen_transition_code.py
@@ -2,6 +2,7 @@ import pathlib
 
 
 template = """import warnings
+
 from {module_name} import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/gen_transition_code.py
+++ b/gen_transition_code.py
@@ -2,7 +2,7 @@ import pathlib
 
 
 template = """import warnings
-
+{extra}
 from {module_name} import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)
@@ -25,8 +25,12 @@ def main():
         if py_file.name != "__init__.py":
             module_name += "." + py_file.name[:-3]
 
+        extra = ""
+        if str(file_path) == "." and py_file.name == "__init__.py":
+            extra = "\nfrom amqtt import __version__"
+
         dst_file.parent.mkdir(parents=True, exist_ok=True)
-        dst_file.write_text(template.format(module_name=module_name))
+        dst_file.write_text(template.format(module_name=module_name, extra=extra))
 
 
 if __name__ == "__main__":

--- a/hbmqtt/__init__.py
+++ b/hbmqtt/__init__.py
@@ -1,4 +1,6 @@
 import warnings
+
+from amqtt import __version__
 from amqtt import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/adapters.py
+++ b/hbmqtt/adapters.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.adapters import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.broker import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/client.py
+++ b/hbmqtt/client.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.client import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/codecs.py
+++ b/hbmqtt/codecs.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.codecs import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/errors.py
+++ b/hbmqtt/errors.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.errors import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/__init__.py
+++ b/hbmqtt/mqtt/__init__.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/connack.py
+++ b/hbmqtt/mqtt/connack.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.connack import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/connect.py
+++ b/hbmqtt/mqtt/connect.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.connect import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/constants.py
+++ b/hbmqtt/mqtt/constants.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.constants import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/disconnect.py
+++ b/hbmqtt/mqtt/disconnect.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.disconnect import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/packet.py
+++ b/hbmqtt/mqtt/packet.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.packet import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/pingreq.py
+++ b/hbmqtt/mqtt/pingreq.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.pingreq import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/pingresp.py
+++ b/hbmqtt/mqtt/pingresp.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.pingresp import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/protocol/__init__.py
+++ b/hbmqtt/mqtt/protocol/__init__.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.protocol import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/protocol/broker_handler.py
+++ b/hbmqtt/mqtt/protocol/broker_handler.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.protocol.broker_handler import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/protocol/client_handler.py
+++ b/hbmqtt/mqtt/protocol/client_handler.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.protocol.client_handler import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/protocol/handler.py
+++ b/hbmqtt/mqtt/protocol/handler.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.protocol.handler import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/puback.py
+++ b/hbmqtt/mqtt/puback.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.puback import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/pubcomp.py
+++ b/hbmqtt/mqtt/pubcomp.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.pubcomp import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/publish.py
+++ b/hbmqtt/mqtt/publish.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.publish import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/pubrec.py
+++ b/hbmqtt/mqtt/pubrec.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.pubrec import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/pubrel.py
+++ b/hbmqtt/mqtt/pubrel.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.pubrel import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/suback.py
+++ b/hbmqtt/mqtt/suback.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.suback import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/subscribe.py
+++ b/hbmqtt/mqtt/subscribe.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.subscribe import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/unsuback.py
+++ b/hbmqtt/mqtt/unsuback.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.unsuback import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/mqtt/unsubscribe.py
+++ b/hbmqtt/mqtt/unsubscribe.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.mqtt.unsubscribe import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/plugins/__init__.py
+++ b/hbmqtt/plugins/__init__.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.plugins import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/plugins/authentication.py
+++ b/hbmqtt/plugins/authentication.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.plugins.authentication import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/plugins/logging.py
+++ b/hbmqtt/plugins/logging.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.plugins.logging import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/plugins/manager.py
+++ b/hbmqtt/plugins/manager.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.plugins.manager import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/plugins/persistence.py
+++ b/hbmqtt/plugins/persistence.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.plugins.persistence import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/plugins/sys/__init__.py
+++ b/hbmqtt/plugins/sys/__init__.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.plugins.sys import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/plugins/sys/broker.py
+++ b/hbmqtt/plugins/sys/broker.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.plugins.sys.broker import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/plugins/topic_checking.py
+++ b/hbmqtt/plugins/topic_checking.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.plugins.topic_checking import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/scripts/__init__.py
+++ b/hbmqtt/scripts/__init__.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.scripts import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/scripts/broker_script.py
+++ b/hbmqtt/scripts/broker_script.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.scripts.broker_script import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/scripts/pub_script.py
+++ b/hbmqtt/scripts/pub_script.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.scripts.pub_script import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/scripts/sub_script.py
+++ b/hbmqtt/scripts/sub_script.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.scripts.sub_script import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/session.py
+++ b/hbmqtt/session.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.session import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/utils.py
+++ b/hbmqtt/utils.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.utils import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/hbmqtt/version.py
+++ b/hbmqtt/version.py
@@ -1,4 +1,5 @@
 import warnings
+
 from amqtt.version import *
 
 warnings.warn("importing hbmqtt is deprecated. Please import amqtt", DeprecationWarning)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,10 @@ hbmqtt = 'amqtt.scripts.broker_script:main'
 hbmqtt_pub = 'amqtt.scripts.pub_script:main'
 hbmqtt_sub = 'amqtt.scripts.sub_script:main'
 
+amqtt = 'amqtt.scripts.broker_script:main'
+amqtt_pub = 'amqtt.scripts.pub_script:main'
+amqtt_sub = 'amqtt.scripts.sub_script:main'
+
 [tool.poetry.plugins]
 
 [tool.poetry.plugins."amqtt.test.plugins"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,29 @@
+import subprocess
+
+
+def test_smometest():
+    output = subprocess.check_output(["amqtt", "--help"])
+    assert b"Usage" in output
+    assert b"aMQTT" in output
+
+    output = subprocess.check_output(["amqtt_sub", "--help"])
+    assert b"Usage" in output
+    assert b"amqtt_sub" in output
+
+    output = subprocess.check_output(["amqtt_pub", "--help"])
+    assert b"Usage" in output
+    assert b"amqtt_pub" in output
+
+
+def test_smometest_legacy():
+    output = subprocess.check_output(["hbmqtt", "--help"])
+    assert b"Usage" in output
+    assert b"aMQTT" in output
+
+    output = subprocess.check_output(["hbmqtt_sub", "--help"])
+    assert b"Usage" in output
+    assert b"amqtt_sub" in output
+
+    output = subprocess.check_output(["hbmqtt_pub", "--help"])
+    assert b"Usage" in output
+    assert b"amqtt_pub" in output


### PR DESCRIPTION
- Make generated `hbmqtt` files follow pep8 by adding a newline between imports
- Explicitly import `__version__` as it is not imported in `import *` since it starts with a `_` (this fixes the hbmqtt cli script)
- add smoketest, closes #57
- add `amqtt`, `amqtt_sub` and `amqtt_pub` cli scripts