### PR TITLE
Do not disregard KeyError exceptions inside plugins

### DIFF
--- a/amqtt/plugins/manager.py
+++ b/amqtt/plugins/manager.py
@@ -194,12 +194,12 @@ class PluginManager:
 
     @staticmethod
     async def _call_coro(plugin, coro_name, *args, **kwargs):
-        try:
-            coro = getattr(plugin.object, coro_name, None)(*args, **kwargs)
-            return await coro
-        except TypeError:
+        if not hasattr(plugin.object, coro_name):
             # Plugin doesn't implement coro_name
             return None
+
+        coro = getattr(plugin.object, coro_name)(*args, **kwargs)
+        return await coro
 
     async def map_plugin_coro(self, coro_name, *args, **kwargs):
         """

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 ---------
 
-0.10.0 - [unreleased]
+0.10.0 - [2021-07-07]
 ---------------------
 
  * first release under new package name: amqtt
@@ -13,6 +13,7 @@ Changelog
  * Move scripts module into hbmqtt module, from https://github.com/beerfactory/hbmqtt/pull/167
  * Download mosquitto certificate on the fly
  * importing `hbmqtt` is deprecated, use `amqtt`
+ * Security fix: If an attacker could produce a KeyError inside an authentication plugin, the authentication was accepted instead of rejected
 
 0.9.5
 .....


### PR DESCRIPTION
If an attacker could produce a KeyError inside an authentication plugin, the authentication was accepted instead of rejected