### PR TITLE
release 0.10.0

### DIFF
--- a/amqtt/__init__.py
+++ b/amqtt/__init__.py
@@ -1,3 +1,3 @@
 # See the file license.txt for copying permission.
 
-__version__ = "0.10.0-alpha.4"
+__version__ = "0.10.0"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 ---------
 
-0.10.0 - [unreleased]
----------------------
+0.10.0 - 2021-07-31
+-------------------
 
  * first release under new package name: amqtt
  * reworked unit tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "amqtt"
-version = "0.10.0-alpha.4"
+version = "0.10.0"
 description = "MQTT client/broker using Python asyncio"
 authors = ["aMQTT Contributers"]
 license = "MIT"


### PR DESCRIPTION

- release `0.10.0`
- create `v0.10.x` branch
- allow changes to `master` that break API compatibility with hbmqtt 
- remove compatibility layer and fully transition to new name