### PR TITLE
Remove loop parameter

### DIFF
--- a/amqtt/mqtt/protocol/broker_handler.py
+++ b/amqtt/mqtt/protocol/broker_handler.py
@@ -32,13 +32,13 @@ class BrokerProtocolHandler(ProtocolHandler):
     ):
         super().__init__(plugins_manager, session, loop)
         self._disconnect_waiter = None
-        self._pending_subscriptions = Queue(loop=self._loop)
-        self._pending_unsubscriptions = Queue(loop=self._loop)
+        self._pending_subscriptions = Queue()
+        self._pending_unsubscriptions = Queue()
 
     async def start(self):
         await super().start()
         if self._disconnect_waiter is None:
-            self._disconnect_waiter = futures.Future(loop=self._loop)
+            self._disconnect_waiter = futures.Future()
 
     async def stop(self):
         await super().stop()

--- a/amqtt/mqtt/protocol/client_handler.py
+++ b/amqtt/mqtt/protocol/client_handler.py
@@ -23,7 +23,7 @@ class ClientProtocolHandler(ProtocolHandler):
     ):
         super().__init__(plugins_manager, session, loop=loop)
         self._ping_task = None
-        self._pingresp_queue = asyncio.Queue(loop=self._loop)
+        self._pingresp_queue = asyncio.Queue()
         self._subscriptions_waiter = dict()
         self._unsubscriptions_waiter = dict()
         self._disconnect_waiter = None
@@ -31,7 +31,7 @@ class ClientProtocolHandler(ProtocolHandler):
     async def start(self):
         await super().start()
         if self._disconnect_waiter is None:
-            self._disconnect_waiter = futures.Future(loop=self._loop)
+            self._disconnect_waiter = futures.Future()
 
     async def stop(self):
         await super().stop()
@@ -105,7 +105,7 @@ class ClientProtocolHandler(ProtocolHandler):
         await self._send_packet(subscribe)
 
         # Wait for SUBACK is received
-        waiter = futures.Future(loop=self._loop)
+        waiter = futures.Future()
         self._subscriptions_waiter[subscribe.variable_header.packet_id] = waiter
         return_codes = await waiter
 
@@ -131,7 +131,7 @@ class ClientProtocolHandler(ProtocolHandler):
         """
         unsubscribe = UnsubscribePacket.build(topics, packet_id)
         await self._send_packet(unsubscribe)
-        waiter = futures.Future(loop=self._loop)
+        waiter = futures.Future()
         self._unsubscriptions_waiter[unsubscribe.variable_header.packet_id] = waiter
         await waiter
         del self._unsubscriptions_waiter[unsubscribe.variable_header.packet_id]

--- a/amqtt/plugins/manager.py
+++ b/amqtt/plugins/manager.py
@@ -109,7 +109,7 @@ class PluginManager:
         return self._plugins
 
     def _schedule_coro(self, coro):
-        return asyncio.ensure_future(coro, loop=self._loop)
+        return asyncio.ensure_future(coro)
 
     async def fire_event(self, event_name, wait=False, *args, **kwargs):
         """
@@ -149,7 +149,7 @@ class PluginManager:
         self._fired_events.extend(tasks)
         if wait:
             if tasks:
-                await asyncio.wait(tasks, loop=self._loop)
+                await asyncio.wait(tasks)
         self.logger.debug("Plugins len(_fired_events)=%d" % (len(self._fired_events)))
 
     async def map(self, coro, *args, **kwargs):
@@ -182,7 +182,7 @@ class PluginManager:
                             % (coro, plugin.name)
                         )
         if tasks:
-            ret_list = await asyncio.gather(*tasks, loop=self._loop)
+            ret_list = await asyncio.gather(*tasks)
             # Create result map plugin=>ret
             ret_dict = {k: v for k, v in zip(plugins_list, ret_list)}
         else:

--- a/amqtt/session.py
+++ b/amqtt/session.py
@@ -139,10 +139,10 @@ class Session:
         self.inflight_in = OrderedDict()
 
         # Stores messages retained for this session
-        self.retained_messages = Queue(loop=self._loop)
+        self.retained_messages = Queue()
 
         # Stores PUBLISH messages ID received in order and ready for application process
-        self.delivered_message_queue = Queue(loop=self._loop)
+        self.delivered_message_queue = Queue()
 
     def _init_states(self):
         self.transitions = Machine(states=Session.states, initial="new")


### PR DESCRIPTION
asyncio loop parameter has been deprecated since 3.8 and is now deleted in 3.10. Default behavior in previous version should work as expected, if I understand it correctly