### PR TITLE
Handle MQTT Client Takeover

### DIFF
--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -478,6 +478,7 @@ class Broker:
                         client_session.client_id,
                     )
                     old_session = self._sessions[client_session.client_id]
+                    await old_session[1].handle_connection_closed()
                     await old_session[1].stop()
                     break
                 else:

--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -458,9 +458,6 @@ class Broker:
             client_session.keep_alive += self.config["timeout-disconnect-delay"]
         self.logger.debug("Keep-alive timeout=%d" % client_session.keep_alive)
 
-        handler.attach(client_session, reader, writer)
-        self._sessions[client_session.client_id] = (client_session, handler)
-
         authenticated = await self.authenticate(
             client_session, self.listeners_config[listener_name]
         )
@@ -475,12 +472,25 @@ class Broker:
                 break
             except (MachineError, ValueError):
                 # Backwards compat: MachineError is raised by transitions < 0.5.0.
-                self.logger.warning(
-                    "Client %s is reconnecting too quickly, make it wait"
-                    % client_session.client_id
-                )
-                # Wait a bit may be client is reconnecting too fast
-                await asyncio.sleep(1)
+                if client_session.transitions.is_connected():
+                    self.logger.warning(
+                        "Client %s is already connected, performing take-over.",
+                        client_session.client_id,
+                    )
+                    old_session = self._sessions[client_session.client_id]
+                    await old_session[1].stop()
+                    break
+                else:
+                    self.logger.warning(
+                        "Client %s is reconnecting too quickly, make it wait"
+                        % client_session.client_id
+                    )
+                    # Wait a bit may be client is reconnecting too fast
+                    await asyncio.sleep(1)
+
+        handler.attach(client_session, reader, writer)
+        self._sessions[client_session.client_id] = (client_session, handler)
+
         await handler.mqtt_connack_authorize(authenticated)
 
         await self.plugins_manager.fire_event(


### PR DESCRIPTION
If a client connected with the same client ID as a currently assumed to be connected client, we will close the previous connection and hand the session over to the new client.

As written by @mbillow for feedernet's fork of hbmqtt.