### PR TITLE
Remove leading slashes from example topics

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -19,23 +19,23 @@ Publishing messages
 Publishing ```some_data`` to as ``/test`` topic on is as simple as :
 ::
 
-    $ amqtt_pub --url mqtt://test.mosquitto.org -t /test -m some_data
+    $ amqtt_pub --url mqtt://test.mosquitto.org -t test -m some_data
     [2015-11-06 22:21:55,108] :: INFO - amqtt_pub/5135-MacBook-Pro.local Connecting to broker
-    [2015-11-06 22:21:55,333] :: INFO - amqtt_pub/5135-MacBook-Pro.local Publishing to '/test'
+    [2015-11-06 22:21:55,333] :: INFO - amqtt_pub/5135-MacBook-Pro.local Publishing to 'test'
     [2015-11-06 22:21:55,336] :: INFO - amqtt_pub/5135-MacBook-Pro.local Disconnected from broker
 
 This will use insecure TCP connection to connect to test.mosquitto.org. ``amqtt_pub`` also allows websockets and secure connection:
 ::
 
-    $ amqtt_pub --url ws://test.mosquitto.org:8080 -t /test -m some_data
+    $ amqtt_pub --url ws://test.mosquitto.org:8080 -t test -m some_data
     [2015-11-06 22:22:42,542] :: INFO - amqtt_pub/5157-MacBook-Pro.local Connecting to broker
-    [2015-11-06 22:22:42,924] :: INFO - amqtt_pub/5157-MacBook-Pro.local Publishing to '/test'
+    [2015-11-06 22:22:42,924] :: INFO - amqtt_pub/5157-MacBook-Pro.local Publishing to 'test'
     [2015-11-06 22:22:52,926] :: INFO - amqtt_pub/5157-MacBook-Pro.local Disconnected from broker
 
 ``amqtt_pub`` can read from file or stdin and use data read as message payload:
 ::
 
-    $ some_command | amqtt_pub --url mqtt://localhost -t /test -l
+    $ some_command | amqtt_pub --url mqtt://localhost -t test -l
 
 See :doc:`references/amqtt_pub` reference documentation for details about available options and settings.
 
@@ -44,10 +44,10 @@ Subscribing a topic
 
 ``amqtt_sub`` is a command-line tool which can be used to subscribe for some pattern(s) on a broker and get date from messages published on topics matching these patterns by other MQTT clients.
 
-Subscribing a ``/test/#`` topic pattern is done with :
+Subscribing a ``test/#`` topic pattern is done with :
 ::
 
-  $ amqtt_sub --url mqtt://localhost -t /test/#
+  $ amqtt_sub --url mqtt://localhost -t test/#
 
 This command will run forever and print on the standard output every messages received from the broker. The ``-n`` option allows to set a maximum number of messages to receive before stopping.
 

--- a/docs/references/hbmqtt_sub.rst
+++ b/docs/references/hbmqtt_sub.rst
@@ -75,7 +75,7 @@ Subscribe with QoS 0 to all messages published under $SYS/:
 Subscribe to 10 messages with QoS 2 from /#:
 ::
 
-    amqtt_sub --url mqtt://localhost -t /# -q 2 -n 10
+    amqtt_sub --url mqtt://localhost -t # -q 2 -n 10
 
 .. _mosquitto_sub : http://mosquitto.org/man/mosquitto_sub-1.html
 

--- a/docs/references/mqttclient.rst
+++ b/docs/references/mqttclient.rst
@@ -176,14 +176,14 @@ Default QoS and default retain can also be overriden by adding a ``topics`` with
         'reconnect_max_interval': 5,
         'reconnect_retries': 10,
         'topics': {
-            '/test': { 'qos': 1 },
-            '/some_topic': { 'qos': 2, 'retain': True }
+            'test': { 'qos': 1 },
+            'some_topic': { 'qos': 2, 'retain': True }
         }
     }
 
 With this setting any message published will set with QOS_0 and retain flag unset except for :
 
-* messages sent to ``/test`` topic : they will be sent with QOS_1
-* messages sent to ``/some_topic`` topic : they will be sent with QOS_2 and retain flag set
+* messages sent to ``test`` topic : they will be sent with QOS_1
+* messages sent to ``some_topic`` topic : they will be sent with QOS_2 and retain flag set
 
 In any case, the ``qos`` and ``retain`` argument values passed to method :meth:`~amqtt.client.MQTTClient.publish` will override these settings.


### PR DESCRIPTION
Use of a leading slash is not best practice and should not appear in examples.