### PR TITLE
fix EventLoggerPlugin.__getattr__

### DIFF
--- a/amqtt/plugins/logging.py
+++ b/amqtt/plugins/logging.py
@@ -19,6 +19,7 @@ class EventLoggerPlugin:
     def __getattr__(self, name):
         if name.startswith("on_"):
             return partial(self.log_event, event_name=name)
+        raise AttributeError
 
 
 class PacketLoggerPlugin:


### PR DESCRIPTION
The EventLoggerPlugin is implementing wrong the method `__getattr__`, which lead to an incorrect check in 
https://github.com/Yakifo/amqtt/blob/8961b8fff57007a5d9907b98bc555f0519974ce9/amqtt/plugins/manager.py#L193-L199

Before the fix the method `hasattr` would return `True` for name like `'topic_filtering'` and the method is not returning `None`. This then will lead to an `'NoneType' object is not callable` in line 199.
On version `0.10.0` this creates an infinite wait for the client to subscribe on topics. Bug was find during migration from hbmqtt to amqtt. Probably this PR fixes also #83 

The python docs says for [` object.__getattr__(self, name)`](https://docs.python.org/3/reference/datamodel.html#object.__getattr__): 
> This method should either return the (computed) attribute value or raise an AttributeError exception.

@FlorianLudwig I think we should cherry pick this PR also for the `0.10.x` branch as I cannot use the `0.10` without this fix and probably others, if they have disabled `topic_check`.