### PR TITLE
don't filter topics if its explicit disabled

### DIFF
--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -725,10 +725,16 @@ class Broker:
         :param action: What is being done with the topic?  subscribe or publish
         :return:
         """
+        topic_result = True
         topic_plugins = None
         topic_config = self.config.get("topic-check", None)
-        if topic_config and topic_config.get("enabled", False):
-            topic_plugins = topic_config.get("plugins", None)
+        # if enabled is not specified, all plugins will be used for topic filtering (backward compatibility)
+        if topic_config and "enabled" in topic_config:
+            if topic_config.get("enabled", False):
+                topic_plugins = topic_config.get("plugins", None)
+            else:
+                return topic_result
+
         returns = await self.plugins_manager.map_plugin_coro(
             "topic_filtering",
             session=session,
@@ -736,7 +742,6 @@ class Broker:
             action=action,
             filter_plugins=topic_plugins,
         )
-        topic_result = True
         if returns:
             for plugin in returns:
                 res = returns[plugin]


### PR DESCRIPTION
During the investigation of #92 I found out, that even when the topic check is disabled via config (`topic-check": {"enabled": False}`). All plugins will be used to check for topic filtering.

The reason is that in the method `topic_filtering` the value `None` is passed for `filter_plugins` to the method `map_plugin_coro`

https://github.com/Yakifo/amqtt/blob/8961b8fff57007a5d9907b98bc555f0519974ce9/amqtt/broker.py#L728-L738

In the manager then, if the value is `None` all available plugins will be used.

https://github.com/Yakifo/amqtt/blob/8961b8fff57007a5d9907b98bc555f0519974ce9/amqtt/plugins/manager.py#L167-L169

My fix will immediately return `True (topic_result)` if in the `topic-check`-configuration explicit `enabled` was set to `False`.
If the key `enabled` is missing all plugins will be used as it was done before (backward compatibility).