### PR TITLE
Fix executable names

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -24,9 +24,9 @@ poetry install --no-dev
 
 Usage:
 ```
-poetry run hbmqtt
-poetry run hbmqtt_pub
-poetry run hbmqtt_sub
+poetry run amqtt
+poetry run amqtt_pub
+poetry run amqtt_sub
 ```
 
 Or you can enter the virtual enviroment via:


### PR DESCRIPTION
The executables have been renamed. This fixes the name in the documentation.