### PR TITLE
Fix asyncio.wait deprecation warnings

### DIFF
--- a/amqtt/client.py
+++ b/amqtt/client.py
@@ -72,7 +72,10 @@ def mqtt_connected(func):
         if not self._connected_state.is_set():
             base_logger.warning("Client not connected, waiting for it")
             _, pending = await asyncio.wait(
-                [self._connected_state.wait(), self._no_more_connections.wait()],
+                [
+                    asyncio.create_task(self._connected_state.wait()),
+                    asyncio.create_task(self._no_more_connections.wait()),
+                ],
                 return_when=asyncio.FIRST_COMPLETED,
             )
             for t in pending:

--- a/amqtt/mqtt/protocol/client_handler.py
+++ b/amqtt/mqtt/protocol/client_handler.py
@@ -26,11 +26,11 @@ class ClientProtocolHandler(ProtocolHandler):
         self._pingresp_queue = asyncio.Queue()
         self._subscriptions_waiter = dict()
         self._unsubscriptions_waiter = dict()
-        self._disconnect_waiter = None
+        self._disconnect_waiter = futures.Future()
 
     async def start(self):
         await super().start()
-        if self._disconnect_waiter is None:
+        if self._disconnect_waiter.cancelled():
             self._disconnect_waiter = futures.Future()
 
     async def stop(self):
@@ -41,7 +41,6 @@ class ClientProtocolHandler(ProtocolHandler):
 
         if not self._disconnect_waiter.done():
             self._disconnect_waiter.cancel()
-        self._disconnect_waiter = None
 
     def _build_connect_packet(self):
         vh = ConnectVariableHeader()

--- a/amqtt/mqtt/protocol/handler.py
+++ b/amqtt/mqtt/protocol/handler.py
@@ -176,7 +176,11 @@ class ProtocolHandler:
         for message in itertools.chain(
             self.session.inflight_in.values(), self.session.inflight_out.values()
         ):
-            tasks.append(asyncio.wait_for(self._handle_message_flow(message), 10))
+            tasks.append(
+                asyncio.create_task(
+                    asyncio.wait_for(self._handle_message_flow(message), 10)
+                )
+            )
         if tasks:
             done, pending = await asyncio.wait(tasks)
             self.logger.debug("%d messages redelivered" % len(done))

--- a/amqtt/mqtt/protocol/handler.py
+++ b/amqtt/mqtt/protocol/handler.py
@@ -128,7 +128,7 @@ class ProtocolHandler:
             raise ProtocolHandlerException("Handler is not attached to a stream")
         self._reader_ready = asyncio.Event()
         self._reader_task = asyncio.Task(self._reader_loop())
-        await asyncio.wait([self._reader_ready.wait()])
+        await self._reader_ready.wait()
         if self.keepalive_timeout:
             self._keepalive_task = self._loop.call_later(
                 self.keepalive_timeout, self.handle_write_timeout
@@ -146,7 +146,7 @@ class ProtocolHandler:
         self.logger.debug("waiting for tasks to be stopped")
         if not self._reader_task.done():
             self._reader_task.cancel()
-            await asyncio.wait([self._reader_stopped.wait()])
+            await self._reader_stopped.wait()
         self.logger.debug("closing writer")
         try:
             await self.writer.close()


### PR DESCRIPTION
Fixes `The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.`