### PR TITLE
run pre-commit on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
 fail_fast: false
-files: ^(tests|samples)/
 repos:
 - repo: local
   hooks:


### PR DESCRIPTION
We should run pre-commit on all files not only tests and samples.
The advantage of pre-commit is that it wan#t let you commit, if the defined checks will not pass