### PR TITLE
Bugfix: client_handler.py

### DIFF
--- a/amqtt/mqtt/protocol/client_handler.py
+++ b/amqtt/mqtt/protocol/client_handler.py
@@ -163,8 +163,7 @@ class ClientProtocolHandler(ProtocolHandler):
 
     async def handle_connection_closed(self):
         self.logger.debug("Broker closed connection")
-        if not self._disconnect_waiter.done():
-            self._disconnect_waiter.set_result(None)
+        await self.stop()
 
     async def wait_disconnect(self):
         await self._disconnect_waiter


### PR DESCRIPTION
More defensive closing of a broken connection.

We saw a rant of messages on instable/unreliable connections:
```
2022-07-28T08:23:17.804100764Z WARNING:asyncio:socket.send() raised exception.
2022-07-28T08:23:17.804102147Z DEBUG:amqtt.mqtt.protocol.handler:Broker closed connection
2022-07-28T08:23:17.804103500Z WARNING:asyncio:socket.send() raised exception.
2022-07-28T08:23:17.804104932Z DEBUG:amqtt.mqtt.protocol.handler:Broker closed connection
2022-07-28T08:23:17.804106265Z WARNING:asyncio:socket.send() raised exception.
2022-07-28T08:23:17.804107587Z DEBUG:amqtt.mqtt.protocol.handler:Broker closed connection
2022-07-28T08:23:17.804108930Z WARNING:asyncio:socket.send() raised exception.
```

These were thrown 10 k/s and flooded logs and the buffer, leading to an instable system.

I think this is due to an unhandled closed connection. Please review the attached MR.