### PR TITLE
Fixes for #126

### DIFF
--- a/amqtt/mqtt/protocol/handler.py
+++ b/amqtt/mqtt/protocol/handler.py
@@ -353,8 +353,7 @@ class ProtocolHandler:
                 waiter = asyncio.Future()
                 self._pubrec_waiters[app_message.packet_id] = waiter
                 try:
-                    await waiter
-                    app_message.pubrec_packet = waiter.result()
+                    app_message.pubrec_packet = await waiter
                 finally:
                     self._pubrec_waiters.pop(app_message.packet_id, None)
                     self.session.inflight_out.pop(app_message.packet_id, None)

--- a/amqtt/mqtt/protocol/handler.py
+++ b/amqtt/mqtt/protocol/handler.py
@@ -365,8 +365,7 @@ class ProtocolHandler:
                 waiter = asyncio.Future()
                 self._pubcomp_waiters[app_message.packet_id] = waiter
                 try:
-                    await waiter
-                    app_message.pubcomp_packet = waiter.result()
+                    app_message.pubcomp_packet = await waiter
                 finally:
                     self._pubcomp_waiters.pop(app_message.packet_id, None)
                     self.session.inflight_out.pop(app_message.packet_id, None)

--- a/amqtt/session.py
+++ b/amqtt/session.py
@@ -159,16 +159,15 @@ class Session:
 
     @property
     def next_packet_id(self):
-        self._packet_id += 1
-        if self._packet_id > 65535:
-            self._packet_id = 1
+        self._packet_id = (self._packet_id % 65535) + 1
+        limit = self._packet_id
         while (
             self._packet_id in self.inflight_in or self._packet_id in self.inflight_out
         ):
-            self._packet_id += 1
-            if self._packet_id > 65535:
+            self._packet_id = (self._packet_id % 65535) + 1
+            if self._packet_id == limit:
                 raise AMQTTException(
-                    "More than 65525 messages pending. No free packet ID"
+                    "More than 65535 messages pending. No free packet ID"
                 )
 
         return self._packet_id


### PR DESCRIPTION
- Updated protocol handlers to more reliably remove active waiters when task cancellation occurs
- Fixed checks where expecting a KeyError when it should be checking if not None
- Updated next_packet_id property to correctly check if there are any packet_ids available. Avoids infinite loop if all packet ids are used.