### PR TITLE
revert accidental commented stopping of handler

### DIFF
--- a/amqtt/client.py
+++ b/amqtt/client.py
@@ -505,7 +505,7 @@ class MQTTClient:
         self._connected_state.clear()
 
         # stop an clean handler
-        # await self._handler.stop()
+        await self._handler.stop()
         self._handler.detach()
         self.session.transitions.disconnect()
 


### PR DESCRIPTION
I commented that line in the big refactor that ported the code to python3. I strongly assume that this was an accidental change which lead to the issue that was reported and fixed in https://github.com/Yakifo/amqtt/pull/119 but in the client handler.