### PR TITLE
#133: Fix task cancellation breaking broadcast loop

### DIFF
--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -886,7 +886,7 @@ class Broker:
                             "Task failed and will be skipped: %s", task
                         )
 
-                run_broadcast_task = self._run_broadcast(running_tasks)
+                run_broadcast_task = asyncio.Task(self._run_broadcast(running_tasks))
 
                 completed, _ = await asyncio.wait(
                     [run_broadcast_task, self._broadcast_shutdown_waiter],
@@ -896,6 +896,7 @@ class Broker:
                 # Shutdown has been triggered by the broker
                 # So stop the loop execution
                 if self._broadcast_shutdown_waiter in completed:
+                    run_broadcast_task.cancel()
                     break
 
         except BaseException:

--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -879,12 +879,12 @@ class Broker:
                     task = running_tasks.popleft()
                     try:
                         task.result()  # make asyncio happy and collect results
+                    except CancelledError:
+                        self.logger.info("Task has been cancelled: %s", task)
                     except Exception:
                         self.logger.exception(
                             "Task failed and will be skipped: %s", task
                         )
-                    except CancelledError:
-                        self.logger.info("Task has been cancelled: %s", task)
 
                 run_broadcast_task = self._run_broadcast(running_tasks)
 

--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -884,7 +884,7 @@ class Broker:
                             "Task failed and will be skipped: %s", task
                         )
                     except CancelledError:
-                        self.logger.warning("Task has been cancelled: %s", task)
+                        self.logger.info("Task has been cancelled: %s", task)
 
                 run_broadcast_task = self._run_broadcast(running_tasks)
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -3,6 +3,7 @@
 # See the file license.txt for copying permission.
 import asyncio
 import logging
+import sys
 from unittest.mock import call, MagicMock, patch
 
 import pytest
@@ -647,7 +648,11 @@ async def test_broker_broadcast_cancellation(broker):
         await _client_publish(topic, data, qos)
         await asyncio.sleep(0.01)
 
-        mocked_mqtt_publish.assert_awaited()
+        # `assert_awaited` does not exist in Python before `3.8`
+        if sys.version_info >= (3, 8):
+            mocked_mqtt_publish.assert_awaited()
+        else:
+            mocked_mqtt_publish.assert_called()
 
     # Ensure broadcast loop is still functional and can deliver the message
     await _client_publish(topic, data, qos)


### PR DESCRIPTION
- Differentiate between broadcast shutdown and task cancellation
- Minor refactor to make the code more readable
- Improved and simplified logging

Closes: https://github.com/Yakifo/amqtt/issues/133