### PR TITLE
client: don't hang indefinitive when the connection break

### DIFF
--- a/amqtt/client.py
+++ b/amqtt/client.py
@@ -494,7 +494,7 @@ class MQTTClient:
             while self.client_tasks:
                 task = self.client_tasks.popleft()
                 if not task.done():
-                    task.set_exception(ClientException("Connection lost"))
+                    task.cancel()
 
         self.logger.debug("Watch broker disconnection")
         # Wait for disconnection from broker (like connection lost)


### PR DESCRIPTION
When the connection closes all client task should terminate. But following example would hang even when the broker closes the connection:

```
mqcli = MQTTClient(config={'auto_reconnect': False})
await mqcli.connect('mqtt://localhost/')
await mqcli.subscribe([('some/topic', QOS_2),])
message = await mqcli.deliver_message()
```

The problem lies in the task.set_exception(). It should terminate all pending task. But the problem is Tasks doesn't support set_exception() and this call raise itself an exception.
As the docs state:
"asyncio.Task inherits from Future all of its APIs except Future.set_result() and Future.set_exception()."

However after implementing it. message will return None without any exception.