### PR TITLE
fix: $SYS broker stats plugin, topics

### DIFF
--- a/amqtt/__init__.py
+++ b/amqtt/__init__.py
@@ -1,3 +1,3 @@
 """INIT."""
 
-__version__ = "0.11.0-beta4"
+__version__ = "0.11.0-rc"

--- a/amqtt/plugins/manager.py
+++ b/amqtt/plugins/manager.py
@@ -196,7 +196,7 @@ class PluginManager:
     @staticmethod
     async def _call_coro(plugin: Plugin, coro_name: str, *args: Any, **kwargs: Any) -> str | bool | None:
         if not hasattr(plugin.object, coro_name):
-            _LOGGER.warning("Plugin doesn't implement coro_name")
+            _LOGGER.warning(f"Plugin doesn't implement coro_name '{coro_name}': {plugin.name}")
             return None
 
         coro: Awaitable[str | bool | None] = getattr(plugin.object, coro_name)(*args, **kwargs)

--- a/amqtt/plugins/sys/broker.py
+++ b/amqtt/plugins/sys/broker.py
@@ -63,7 +63,7 @@ class BrokerSysPlugin:
     async def on_broker_post_start(self, *args: None, **kwargs: None) -> None:
         """Initialize statistics and start $SYS broadcasting."""
         self._stats[STAT_START_TIME] = int(datetime.now(tz=UTC).timestamp())
-        version = f"HBMQTT version {amqtt.__version__}"
+        version = f"aMQTT version {amqtt.__version__}"
         self.context.retain_message(DOLLAR_SYS_ROOT + "version", version.encode())
 
         # Start $SYS topics management
@@ -114,8 +114,8 @@ class BrokerSysPlugin:
             "messages/received": self._stats[STAT_MSG_RECEIVED],
             "messages/sent": self._stats[STAT_MSG_SENT],
             "time": int(datetime.now(tz=UTC).timestamp()),
-            "uptime": str(datetime.fromtimestamp(uptime, UTC)),
-            "uptime/formatted": str(uptime),
+            "uptime": str(uptime),
+            "uptime/formatted": str(datetime.fromtimestamp(self._stats[STAT_START_TIME], UTC)),
             "clients/connected": client_connected,
             "clients/disconnected": client_disconnected,
             "clients/maximum": self._stats[STAT_CLIENTS_MAXIMUM],


### PR DESCRIPTION
Fixes #180

Additionally:

- topics `uptime` and `uptime/formatted` were incorrectly formatted
- improves warning message for plugins
- `version` topic should be `aMQTT` instead of the `HBMQTT`