### PR TITLE
Fixing QoS test cases

### DIFF
--- a/amqtt/mqtt/packet.py
+++ b/amqtt/mqtt/packet.py
@@ -1,4 +1,3 @@
-import logging
 from abc import ABC, abstractmethod
 import asyncio
 
@@ -32,9 +31,6 @@ PINGREQ = 0x0C
 PINGRESP = 0x0D
 DISCONNECT = 0x0E
 RESERVED_15 = 0x0F
-
-
-logger = logging.getLogger(__name__)
 
 
 class MQTTFixedHeader:
@@ -210,7 +206,6 @@ class MQTTPacket(Generic[_VH, _P, _FH]):
 
     async def to_stream(self, writer: WriterAdapter) -> None:
         """Write the entire packet to the stream."""
-        logger.debug(f">> writing packet to stream: {self}")
         writer.write(self.to_bytes())
         await writer.drain()
         self.protocol_ts = datetime.now(UTC)
@@ -253,7 +248,6 @@ class MQTTPacket(Generic[_VH, _P, _FH]):
         else:
             instance = cls(fixed_header, variable_header, payload)
         instance.protocol_ts = datetime.now(UTC)
-        logger.debug(f">> read packet from stream: {instance!r}")
         return instance
 
     @property

--- a/amqtt/mqtt/packet.py
+++ b/amqtt/mqtt/packet.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABC, abstractmethod
 import asyncio
 
@@ -31,6 +32,9 @@ PINGREQ = 0x0C
 PINGRESP = 0x0D
 DISCONNECT = 0x0E
 RESERVED_15 = 0x0F
+
+
+logger = logging.getLogger(__name__)
 
 
 class MQTTFixedHeader:
@@ -206,6 +210,7 @@ class MQTTPacket(Generic[_VH, _P, _FH]):
 
     async def to_stream(self, writer: WriterAdapter) -> None:
         """Write the entire packet to the stream."""
+        logger.debug(f">> writing packet to stream: {self}")
         writer.write(self.to_bytes())
         await writer.drain()
         self.protocol_ts = datetime.now(UTC)
@@ -248,6 +253,7 @@ class MQTTPacket(Generic[_VH, _P, _FH]):
         else:
             instance = cls(fixed_header, variable_header, payload)
         instance.protocol_ts = datetime.now(UTC)
+        logger.debug(f">> read packet from stream: {instance!r}")
         return instance
 
     @property

--- a/amqtt/mqtt/protocol/handler.py
+++ b/amqtt/mqtt/protocol/handler.py
@@ -446,7 +446,7 @@ class ProtocolHandler:
         self.logger.debug(f"{self.session.client_id} Starting reader coro")
         running_tasks: collections.deque[asyncio.Task[None]] = collections.deque()
         keepalive_timeout: int | None = self.session.keep_alive
-        if keepalive_timeout and keepalive_timeout <= 0:
+        if keepalive_timeout is not None and keepalive_timeout <= 0:
             keepalive_timeout = None
         while True:
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,14 +146,14 @@ max-returns = 10
 
 # ----------------------------------- PYTEST -----------------------------------
 [tool.pytest.ini_options]
-#addopts = ["--cov=amqtt", "--cov-report=term-missing", "--cov-report=xml"]
-addopts = ["--tb=short", "--capture=tee-sys"]
+addopts = ["--cov=amqtt", "--cov-report=term-missing", "--cov-report=xml"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 timeout = 10
 asyncio_default_fixture_loop_scope = "function"
-log_cli = true
-log_level = "DEBUG"
+#addopts = ["--tb=short", "--capture=tee-sys"]
+#log_cli = true
+#log_level = "DEBUG"
 
 # ------------------------------------ MYPY ------------------------------------
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,13 +146,14 @@ max-returns = 10
 
 # ----------------------------------- PYTEST -----------------------------------
 [tool.pytest.ini_options]
-addopts = ["--cov=amqtt", "--cov-report=term-missing", "--cov-report=xml"]
+#addopts = ["--cov=amqtt", "--cov-report=term-missing", "--cov-report=xml"]
+addopts = ["--tb=short", "--capture=tee-sys"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 timeout = 10
 asyncio_default_fixture_loop_scope = "function"
-# log_cli = true
-# log_level = "INFO"
+log_cli = true
+log_level = "DEBUG"
 
 # ------------------------------------ MYPY ------------------------------------
 [tool.mypy]

--- a/tests/mqtt/protocol/test_handler.py
+++ b/tests/mqtt/protocol/test_handler.py
@@ -39,7 +39,7 @@ class ProtocolHandlerTest(unittest.TestCase):
 
     def test_init_handler(self):
         Session()
-        handler = ProtocolHandler(self.plugin_manager)
+        handler = ProtocolHandler(self.plugin_manager, loop=self.loop)
         assert handler.session is None
         assert handler._loop is self.loop
         self.check_empty_waiters(handler)

--- a/tests/mqtt/protocol/test_handler.py
+++ b/tests/mqtt/protocol/test_handler.py
@@ -1,508 +1,508 @@
-# import asyncio
-# import logging
-# import secrets
-# from typing import Any
-# import unittest
+import asyncio
+import logging
+import secrets
+from typing import Any
+import unittest
 
-# from amqtt.adapters import StreamReaderAdapter, StreamWriterAdapter
-# from amqtt.mqtt.constants import QOS_0, QOS_1, QOS_2
-# from amqtt.mqtt.protocol.handler import ProtocolHandler
-# from amqtt.mqtt.puback import PubackPacket
-# from amqtt.mqtt.pubcomp import PubcompPacket
-# from amqtt.mqtt.publish import PublishPacket
-# from amqtt.mqtt.pubrec import PubrecPacket
-# from amqtt.mqtt.pubrel import PubrelPacket
-# from amqtt.plugins.manager import PluginManager
-# from amqtt.session import IncomingApplicationMessage, OutgoingApplicationMessage, Session
+from amqtt.adapters import StreamReaderAdapter, StreamWriterAdapter
+from amqtt.mqtt.constants import QOS_0, QOS_1, QOS_2
+from amqtt.mqtt.protocol.handler import ProtocolHandler
+from amqtt.mqtt.puback import PubackPacket
+from amqtt.mqtt.pubcomp import PubcompPacket
+from amqtt.mqtt.publish import PublishPacket
+from amqtt.mqtt.pubrec import PubrecPacket
+from amqtt.mqtt.pubrel import PubrelPacket
+from amqtt.plugins.manager import PluginManager
+from amqtt.session import IncomingApplicationMessage, OutgoingApplicationMessage, Session
 
-# formatter = "[%(asctime)s] %(name)s {%(filename)s:%(lineno)d} %(levelname)s - %(message)s"
-# logging.basicConfig(level=logging.DEBUG, format=formatter)
-# log = logging.getLogger(__name__)
-
-
-# def rand_packet_id():
-#     return secrets.randbelow(65536)
+formatter = "[%(asctime)s] %(name)s {%(filename)s:%(lineno)d} %(levelname)s - %(message)s"
+logging.basicConfig(level=logging.DEBUG, format=formatter)
+log = logging.getLogger(__name__)
 
 
-# def adapt(reader, writer):
-#     return StreamReaderAdapter(reader), StreamWriterAdapter(writer)
+def rand_packet_id():
+    return secrets.randbelow(65536)
 
 
-# class ProtocolHandlerTest(unittest.TestCase):
-#     def setUp(self):
-#         self.loop = asyncio.new_event_loop()
-#         asyncio.set_event_loop(self.loop)
-#         self.plugin_manager = PluginManager("amqtt.test.plugins", context=None)
+def adapt(reader, writer):
+    return StreamReaderAdapter(reader), StreamWriterAdapter(writer)
 
-#     def tearDown(self):
-#         self.loop.close()
 
-#     def test_init_handler(self):
-#         Session()
-#         handler = ProtocolHandler(self.plugin_manager)
-#         assert handler.session is None
-#         assert handler._loop is self.loop
-#         self.check_empty_waiters(handler)
+class ProtocolHandlerTest(unittest.TestCase):
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+        self.plugin_manager = PluginManager("amqtt.test.plugins", context=None)
 
-#     def test_start_stop(self):
-#         async def server_mock(reader, writer) -> None:
-#             pass
+    def tearDown(self):
+        self.loop.close()
 
-#         async def test_coro() -> None:
-#             try:
-#                 s = Session()
-#                 reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
-#                 reader_adapted, writer_adapted = adapt(reader, writer)
-#                 handler = ProtocolHandler(self.plugin_manager)
-#                 handler.attach(s, reader_adapted, writer_adapted)
-#                 await self.start_handler(handler, s)
-#                 await self.stop_handler(handler, s)
-#                 future.set_result(True)
-#             except Exception as ae:
-#                 future.set_exception(ae)
+    def test_init_handler(self):
+        Session()
+        handler = ProtocolHandler(self.plugin_manager)
+        assert handler.session is None
+        assert handler._loop is self.loop
+        self.check_empty_waiters(handler)
 
-#         future: asyncio.Future[Any] = asyncio.Future()
-#         coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
-#         server = self.loop.run_until_complete(coro)
-#         self.loop.run_until_complete(test_coro())
-#         server.close()
-#         self.loop.run_until_complete(server.wait_closed())
-#         exception = future.exception()
-#         if exception:
-#             raise exception
+    def test_start_stop(self):
+        async def server_mock(reader, writer) -> None:
+            pass
 
-#     def test_publish_qos0(self):
-#         async def server_mock(reader, writer) -> None:
-#             try:
-#                 packet = await PublishPacket.from_stream(reader)
-#                 assert packet.variable_header.topic_name == "/topic"
-#                 assert packet.qos == QOS_0
-#                 assert packet.packet_id is None
-#             except Exception as ae:
-#                 future.set_exception(ae)
+        async def test_coro() -> None:
+            try:
+                s = Session()
+                reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
+                reader_adapted, writer_adapted = adapt(reader, writer)
+                handler = ProtocolHandler(self.plugin_manager)
+                handler.attach(s, reader_adapted, writer_adapted)
+                await self.start_handler(handler, s)
+                await self.stop_handler(handler, s)
+                future.set_result(True)
+            except Exception as ae:
+                future.set_exception(ae)
 
-#         async def test_coro() -> None:
-#             try:
-#                 s = Session()
-#                 reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
-#                 reader_adapted, writer_adapted = adapt(reader, writer)
-#                 handler = ProtocolHandler(self.plugin_manager)
-#                 handler.attach(s, reader_adapted, writer_adapted)
-#                 await self.start_handler(handler, s)
-#                 message = await handler.mqtt_publish(
-#                     "/topic",
-#                     b"test_data",
-#                     QOS_0,
-#                     False,
-#                 )
-#                 assert isinstance(message, OutgoingApplicationMessage)
-#                 assert message.publish_packet is not None
-#                 assert message.puback_packet is None
-#                 assert message.pubrec_packet is None
-#                 assert message.pubrel_packet is None
-#                 assert message.pubcomp_packet is None
-#                 await self.stop_handler(handler, s)
-#                 future.set_result(True)
-#             except Exception as ae:
-#                 future.set_exception(ae)
+        future: asyncio.Future[Any] = asyncio.Future()
+        coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
+        server = self.loop.run_until_complete(coro)
+        self.loop.run_until_complete(test_coro())
+        server.close()
+        self.loop.run_until_complete(server.wait_closed())
+        exception = future.exception()
+        if exception:
+            raise exception
 
-#         future: asyncio.Future[Any] = asyncio.Future()
-#         coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
-#         server = self.loop.run_until_complete(coro)
-#         self.loop.run_until_complete(test_coro())
-#         server.close()
-#         self.loop.run_until_complete(server.wait_closed())
-#         exception = future.exception()
-#         if exception:
-#             raise exception
+    def test_publish_qos0(self):
+        async def server_mock(reader, writer) -> None:
+            try:
+                packet = await PublishPacket.from_stream(reader)
+                assert packet.variable_header.topic_name == "/topic"
+                assert packet.qos == QOS_0
+                assert packet.packet_id is None
+            except Exception as ae:
+                future.set_exception(ae)
 
-#     def test_publish_qos1(self):
-#         self.handler: ProtocolHandler | None = None
+        async def test_coro() -> None:
+            try:
+                s = Session()
+                reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
+                reader_adapted, writer_adapted = adapt(reader, writer)
+                handler = ProtocolHandler(self.plugin_manager)
+                handler.attach(s, reader_adapted, writer_adapted)
+                await self.start_handler(handler, s)
+                message = await handler.mqtt_publish(
+                    "/topic",
+                    b"test_data",
+                    QOS_0,
+                    False,
+                )
+                assert isinstance(message, OutgoingApplicationMessage)
+                assert message.publish_packet is not None
+                assert message.puback_packet is None
+                assert message.pubrec_packet is None
+                assert message.pubrel_packet is None
+                assert message.pubcomp_packet is None
+                await self.stop_handler(handler, s)
+                future.set_result(True)
+            except Exception as ae:
+                future.set_exception(ae)
 
-#         async def server_mock(reader, writer) -> None:
-#             packet = await PublishPacket.from_stream(reader)
-#             try:
-#                 assert packet.variable_header.topic_name == "/topic"
-#                 assert packet.qos == QOS_1
-#                 assert packet.packet_id is not None
-#                 assert packet.packet_id in self.session.inflight_out
-#                 assert self.handler is not None
-#                 assert packet.packet_id in self.handler._puback_waiters
-#                 puback = PubackPacket.build(packet.packet_id)
-#                 await puback.to_stream(writer)
-#             except Exception as ae:
-#                 future.set_exception(ae)
+        future: asyncio.Future[Any] = asyncio.Future()
+        coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
+        server = self.loop.run_until_complete(coro)
+        self.loop.run_until_complete(test_coro())
+        server.close()
+        self.loop.run_until_complete(server.wait_closed())
+        exception = future.exception()
+        if exception:
+            raise exception
 
-#         async def test_coro() -> None:
-#             try:
-#                 reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
-#                 reader_adapted, writer_adapted = adapt(reader, writer)
-#                 self.handler = ProtocolHandler(self.plugin_manager)
-#                 self.handler.attach(self.session, reader_adapted, writer_adapted)
-#                 await self.start_handler(self.handler, self.session)
-#                 message = await self.handler.mqtt_publish(
-#                     "/topic",
-#                     b"test_data",
-#                     QOS_1,
-#                     False,
-#                 )
-#                 assert isinstance(message, OutgoingApplicationMessage)
-#                 assert message.publish_packet is not None
-#                 assert message.puback_packet is not None
-#                 assert message.pubrec_packet is None
-#                 assert message.pubrel_packet is None
-#                 assert message.pubcomp_packet is None
-#                 await self.stop_handler(self.handler, self.session)
-#                 if not future.done():
-#                     future.set_result(True)
-#             except Exception as ae:
-#                 future.set_exception(ae)
+    def test_publish_qos1(self):
+        self.handler: ProtocolHandler | None = None
 
-#         self.handler = None
-#         self.session = Session()
-#         future: asyncio.Future[Any] = asyncio.Future()
+        async def server_mock(reader, writer) -> None:
+            packet = await PublishPacket.from_stream(reader)
+            try:
+                assert packet.variable_header.topic_name == "/topic"
+                assert packet.qos == QOS_1
+                assert packet.packet_id is not None
+                assert packet.packet_id in self.session.inflight_out
+                assert self.handler is not None
+                assert packet.packet_id in self.handler._puback_waiters
+                puback = PubackPacket.build(packet.packet_id)
+                await puback.to_stream(writer)
+            except Exception as ae:
+                future.set_exception(ae)
 
-#         coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
-#         server = self.loop.run_until_complete(coro)
-#         self.loop.run_until_complete(test_coro())
-#         server.close()
-#         self.loop.run_until_complete(server.wait_closed())
-#         exception = future.exception()
-#         if exception:
-#             raise exception
+        async def test_coro() -> None:
+            try:
+                reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
+                reader_adapted, writer_adapted = adapt(reader, writer)
+                self.handler = ProtocolHandler(self.plugin_manager)
+                self.handler.attach(self.session, reader_adapted, writer_adapted)
+                await self.start_handler(self.handler, self.session)
+                message = await self.handler.mqtt_publish(
+                    "/topic",
+                    b"test_data",
+                    QOS_1,
+                    False,
+                )
+                assert isinstance(message, OutgoingApplicationMessage)
+                assert message.publish_packet is not None
+                assert message.puback_packet is not None
+                assert message.pubrec_packet is None
+                assert message.pubrel_packet is None
+                assert message.pubcomp_packet is None
+                await self.stop_handler(self.handler, self.session)
+                if not future.done():
+                    future.set_result(True)
+            except Exception as ae:
+                future.set_exception(ae)
 
-#     def test_publish_qos2(self):
-#         async def server_mock(reader, writer) -> None:
-#             try:
-#                 packet = await PublishPacket.from_stream(reader)
-#                 assert packet.topic_name == "/topic"
-#                 assert packet.qos == QOS_2
-#                 assert packet.packet_id is not None
-#                 assert packet.packet_id in self.session.inflight_out
-#                 assert self.handler is not None
-#                 assert packet.packet_id in self.handler._pubrec_waiters
-#                 pubrec = PubrecPacket.build(packet.packet_id)
-#                 await pubrec.to_stream(writer)
+        self.handler = None
+        self.session = Session()
+        future: asyncio.Future[Any] = asyncio.Future()
 
-#                 await PubrelPacket.from_stream(reader)
-#                 assert packet.packet_id in self.handler._pubcomp_waiters
-#                 pubcomp = PubcompPacket.build(packet.packet_id)
-#                 await pubcomp.to_stream(writer)
-#             except Exception as ae:
-#                 future.set_exception(ae)
+        coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
+        server = self.loop.run_until_complete(coro)
+        self.loop.run_until_complete(test_coro())
+        server.close()
+        self.loop.run_until_complete(server.wait_closed())
+        exception = future.exception()
+        if exception:
+            raise exception
 
-#         async def test_coro() -> None:
-#             try:
-#                 reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
-#                 reader_adapted, writer_adapted = adapt(reader, writer)
-#                 self.handler = ProtocolHandler(self.plugin_manager)
-#                 self.handler.attach(self.session, reader_adapted, writer_adapted)
-#                 await self.start_handler(self.handler, self.session)
-#                 message = await self.handler.mqtt_publish(
-#                     "/topic",
-#                     b"test_data",
-#                     QOS_2,
-#                     False,
-#                 )
-#                 assert isinstance(message, OutgoingApplicationMessage)
-#                 assert message.publish_packet is not None
-#                 assert message.puback_packet is None
-#                 assert message.pubrec_packet is not None
-#                 assert message.pubrel_packet is not None
-#                 assert message.pubcomp_packet is not None
-#                 await self.stop_handler(self.handler, self.session)
-#                 if not future.done():
-#                     future.set_result(True)
-#             except Exception as ae:
-#                 future.set_exception(ae)
+    def test_publish_qos2(self):
+        async def server_mock(reader, writer) -> None:
+            try:
+                packet = await PublishPacket.from_stream(reader)
+                assert packet.topic_name == "/topic"
+                assert packet.qos == QOS_2
+                assert packet.packet_id is not None
+                assert packet.packet_id in self.session.inflight_out
+                assert self.handler is not None
+                assert packet.packet_id in self.handler._pubrec_waiters
+                pubrec = PubrecPacket.build(packet.packet_id)
+                await pubrec.to_stream(writer)
 
-#         self.handler = None
-#         self.session = Session()
-#         future: asyncio.Future[Any] = asyncio.Future()
+                await PubrelPacket.from_stream(reader)
+                assert packet.packet_id in self.handler._pubcomp_waiters
+                pubcomp = PubcompPacket.build(packet.packet_id)
+                await pubcomp.to_stream(writer)
+            except Exception as ae:
+                future.set_exception(ae)
 
-#         coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
-#         server = self.loop.run_until_complete(coro)
-#         self.loop.run_until_complete(test_coro())
-#         server.close()
-#         self.loop.run_until_complete(server.wait_closed())
-#         exception = future.exception()
-#         if exception:
-#             raise exception
+        async def test_coro() -> None:
+            try:
+                reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
+                reader_adapted, writer_adapted = adapt(reader, writer)
+                self.handler = ProtocolHandler(self.plugin_manager)
+                self.handler.attach(self.session, reader_adapted, writer_adapted)
+                await self.start_handler(self.handler, self.session)
+                message = await self.handler.mqtt_publish(
+                    "/topic",
+                    b"test_data",
+                    QOS_2,
+                    False,
+                )
+                assert isinstance(message, OutgoingApplicationMessage)
+                assert message.publish_packet is not None
+                assert message.puback_packet is None
+                assert message.pubrec_packet is not None
+                assert message.pubrel_packet is not None
+                assert message.pubcomp_packet is not None
+                await self.stop_handler(self.handler, self.session)
+                if not future.done():
+                    future.set_result(True)
+            except Exception as ae:
+                future.set_exception(ae)
 
-#     def test_receive_qos0(self):
-#         async def server_mock(reader, writer) -> None:
-#             packet = PublishPacket.build(
-#                 "/topic",
-#                 b"test_data",
-#                 rand_packet_id(),
-#                 False,
-#                 QOS_0,
-#                 False,
-#             )
-#             await packet.to_stream(writer)
+        self.handler = None
+        self.session = Session()
+        future: asyncio.Future[Any] = asyncio.Future()
 
-#         async def test_coro() -> None:
-#             try:
-#                 reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
-#                 reader_adapted, writer_adapted = adapt(reader, writer)
-#                 self.handler = ProtocolHandler(self.plugin_manager)
-#                 self.handler.attach(self.session, reader_adapted, writer_adapted)
-#                 await self.start_handler(self.handler, self.session)
-#                 message = await self.handler.mqtt_deliver_next_message()
-#                 assert isinstance(message, IncomingApplicationMessage)
-#                 assert message.publish_packet is not None
-#                 assert message.puback_packet is None
-#                 assert message.pubrec_packet is None
-#                 assert message.pubrel_packet is None
-#                 assert message.pubcomp_packet is None
-#                 await self.stop_handler(self.handler, self.session)
-#                 future.set_result(True)
-#             except Exception as ae:
-#                 future.set_exception(ae)
+        coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
+        server = self.loop.run_until_complete(coro)
+        self.loop.run_until_complete(test_coro())
+        server.close()
+        self.loop.run_until_complete(server.wait_closed())
+        exception = future.exception()
+        if exception:
+            raise exception
 
-#         self.handler = None
-#         self.session = Session()
-#         future: asyncio.Future[Any] = asyncio.Future()
-#         coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
-#         server = self.loop.run_until_complete(coro)
-#         self.loop.run_until_complete(test_coro())
-#         server.close()
-#         self.loop.run_until_complete(server.wait_closed())
-#         exception = future.exception()
-#         if exception:
-#             raise exception
+    def test_receive_qos0(self):
+        async def server_mock(reader, writer) -> None:
+            packet = PublishPacket.build(
+                "/topic",
+                b"test_data",
+                rand_packet_id(),
+                False,
+                QOS_0,
+                False,
+            )
+            await packet.to_stream(writer)
 
-#     def test_receive_qos1(self):
-#         async def server_mock(reader, writer) -> None:
-#             try:
-#                 packet = PublishPacket.build(
-#                     "/topic",
-#                     b"test_data",
-#                     rand_packet_id(),
-#                     False,
-#                     QOS_1,
-#                     False,
-#                 )
-#                 await packet.to_stream(writer)
-#                 puback = await PubackPacket.from_stream(reader)
-#                 assert puback is not None
-#                 assert packet.packet_id == puback.packet_id
-#             except Exception as ae:
-#                 future.set_exception(ae)
+        async def test_coro() -> None:
+            try:
+                reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
+                reader_adapted, writer_adapted = adapt(reader, writer)
+                self.handler = ProtocolHandler(self.plugin_manager)
+                self.handler.attach(self.session, reader_adapted, writer_adapted)
+                await self.start_handler(self.handler, self.session)
+                message = await self.handler.mqtt_deliver_next_message()
+                assert isinstance(message, IncomingApplicationMessage)
+                assert message.publish_packet is not None
+                assert message.puback_packet is None
+                assert message.pubrec_packet is None
+                assert message.pubrel_packet is None
+                assert message.pubcomp_packet is None
+                await self.stop_handler(self.handler, self.session)
+                future.set_result(True)
+            except Exception as ae:
+                future.set_exception(ae)
 
-#         async def test_coro() -> None:
-#             try:
-#                 reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
-#                 reader_adapted, writer_adapted = adapt(reader, writer)
-#                 self.handler = ProtocolHandler(self.plugin_manager)
-#                 self.handler.attach(self.session, reader_adapted, writer_adapted)
-#                 await self.start_handler(self.handler, self.session)
-#                 message = await self.handler.mqtt_deliver_next_message()
-#                 assert isinstance(message, IncomingApplicationMessage)
-#                 assert message.publish_packet is not None
-#                 assert message.puback_packet is not None
-#                 assert message.pubrec_packet is None
-#                 assert message.pubrel_packet is None
-#                 assert message.pubcomp_packet is None
-#                 await self.stop_handler(self.handler, self.session)
-#                 future.set_result(True)
-#             except Exception as ae:
-#                 future.set_exception(ae)
+        self.handler = None
+        self.session = Session()
+        future: asyncio.Future[Any] = asyncio.Future()
+        coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
+        server = self.loop.run_until_complete(coro)
+        self.loop.run_until_complete(test_coro())
+        server.close()
+        self.loop.run_until_complete(server.wait_closed())
+        exception = future.exception()
+        if exception:
+            raise exception
 
-#         self.handler = None
-#         self.session = Session()
-#         future: asyncio.Future[Any] = asyncio.Future()
-#         self.event = asyncio.Event()
-#         coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
-#         server = self.loop.run_until_complete(coro)
-#         self.loop.run_until_complete(test_coro())
-#         server.close()
-#         self.loop.run_until_complete(server.wait_closed())
-#         exception = future.exception()
-#         if exception:
-#             raise exception
+    def test_receive_qos1(self):
+        async def server_mock(reader, writer) -> None:
+            try:
+                packet = PublishPacket.build(
+                    "/topic",
+                    b"test_data",
+                    rand_packet_id(),
+                    False,
+                    QOS_1,
+                    False,
+                )
+                await packet.to_stream(writer)
+                puback = await PubackPacket.from_stream(reader)
+                assert puback is not None
+                assert packet.packet_id == puback.packet_id
+            except Exception as ae:
+                future.set_exception(ae)
 
-#     def test_receive_qos2(self):
-#         async def server_mock(reader, writer) -> None:
-#             try:
-#                 packet = PublishPacket.build(
-#                     "/topic",
-#                     b"test_data",
-#                     rand_packet_id(),
-#                     False,
-#                     QOS_2,
-#                     False,
-#                 )
-#                 await packet.to_stream(writer)
-#                 pubrec = await PubrecPacket.from_stream(reader)
-#                 assert pubrec is not None
-#                 assert packet.packet_id == pubrec.packet_id
-#                 assert self.handler is not None
-#                 assert packet.packet_id in self.handler._pubrel_waiters
-#                 pubrel = PubrelPacket.build(packet.packet_id)
-#                 await pubrel.to_stream(writer)
-#                 pubcomp = await PubcompPacket.from_stream(reader)
-#                 assert pubcomp is not None
-#                 assert packet.packet_id == pubcomp.packet_id
-#             except Exception as ae:
-#                 future.set_exception(ae)
+        async def test_coro() -> None:
+            try:
+                reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
+                reader_adapted, writer_adapted = adapt(reader, writer)
+                self.handler = ProtocolHandler(self.plugin_manager)
+                self.handler.attach(self.session, reader_adapted, writer_adapted)
+                await self.start_handler(self.handler, self.session)
+                message = await self.handler.mqtt_deliver_next_message()
+                assert isinstance(message, IncomingApplicationMessage)
+                assert message.publish_packet is not None
+                assert message.puback_packet is not None
+                assert message.pubrec_packet is None
+                assert message.pubrel_packet is None
+                assert message.pubcomp_packet is None
+                await self.stop_handler(self.handler, self.session)
+                future.set_result(True)
+            except Exception as ae:
+                future.set_exception(ae)
 
-#         async def test_coro() -> None:
-#             try:
-#                 reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
-#                 reader_adapted, writer_adapted = adapt(reader, writer)
-#                 self.handler = ProtocolHandler(self.plugin_manager)
-#                 self.handler.attach(self.session, reader_adapted, writer_adapted)
-#                 await self.start_handler(self.handler, self.session)
-#                 message = await self.handler.mqtt_deliver_next_message()
-#                 assert isinstance(message, IncomingApplicationMessage)
-#                 assert message.publish_packet is not None
-#                 assert message.puback_packet is None
-#                 assert message.pubrec_packet is not None
-#                 assert message.pubrel_packet is not None
-#                 assert message.pubcomp_packet is not None
-#                 await self.stop_handler(self.handler, self.session)
-#                 future.set_result(True)
-#             except Exception as ae:
-#                 future.set_exception(ae)
+        self.handler = None
+        self.session = Session()
+        future: asyncio.Future[Any] = asyncio.Future()
+        self.event = asyncio.Event()
+        coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
+        server = self.loop.run_until_complete(coro)
+        self.loop.run_until_complete(test_coro())
+        server.close()
+        self.loop.run_until_complete(server.wait_closed())
+        exception = future.exception()
+        if exception:
+            raise exception
 
-#         self.handler = None
-#         self.session = Session()
-#         future: asyncio.Future[Any] = asyncio.Future()
-#         coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
-#         server = self.loop.run_until_complete(coro)
-#         self.loop.run_until_complete(test_coro())
-#         server.close()
-#         self.loop.run_until_complete(server.wait_closed())
-#         exception = future.exception()
-#         if exception:
-#             raise exception
+    def test_receive_qos2(self):
+        async def server_mock(reader, writer) -> None:
+            try:
+                packet = PublishPacket.build(
+                    "/topic",
+                    b"test_data",
+                    rand_packet_id(),
+                    False,
+                    QOS_2,
+                    False,
+                )
+                await packet.to_stream(writer)
+                pubrec = await PubrecPacket.from_stream(reader)
+                assert pubrec is not None
+                assert packet.packet_id == pubrec.packet_id
+                assert self.handler is not None
+                assert packet.packet_id in self.handler._pubrel_waiters
+                pubrel = PubrelPacket.build(packet.packet_id)
+                await pubrel.to_stream(writer)
+                pubcomp = await PubcompPacket.from_stream(reader)
+                assert pubcomp is not None
+                assert packet.packet_id == pubcomp.packet_id
+            except Exception as ae:
+                future.set_exception(ae)
 
-#     async def start_handler(self, handler, session):
-#         self.check_empty_waiters(handler)
-#         self.check_no_message(session)
-#         await handler.start()
-#         assert handler._reader_ready
+        async def test_coro() -> None:
+            try:
+                reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
+                reader_adapted, writer_adapted = adapt(reader, writer)
+                self.handler = ProtocolHandler(self.plugin_manager)
+                self.handler.attach(self.session, reader_adapted, writer_adapted)
+                await self.start_handler(self.handler, self.session)
+                message = await self.handler.mqtt_deliver_next_message()
+                assert isinstance(message, IncomingApplicationMessage)
+                assert message.publish_packet is not None
+                assert message.puback_packet is None
+                assert message.pubrec_packet is not None
+                assert message.pubrel_packet is not None
+                assert message.pubcomp_packet is not None
+                await self.stop_handler(self.handler, self.session)
+                future.set_result(True)
+            except Exception as ae:
+                future.set_exception(ae)
 
-#     async def stop_handler(self, handler, session):
-#         await handler.stop()
-#         assert handler._reader_stopped
-#         self.check_empty_waiters(handler)
-#         self.check_no_message(session)
+        self.handler = None
+        self.session = Session()
+        future: asyncio.Future[Any] = asyncio.Future()
+        coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
+        server = self.loop.run_until_complete(coro)
+        self.loop.run_until_complete(test_coro())
+        server.close()
+        self.loop.run_until_complete(server.wait_closed())
+        exception = future.exception()
+        if exception:
+            raise exception
 
-#     def check_empty_waiters(self, handler):
-#         assert not handler._puback_waiters
-#         assert not handler._pubrec_waiters
-#         assert not handler._pubrel_waiters
-#         assert not handler._pubcomp_waiters
+    async def start_handler(self, handler, session):
+        self.check_empty_waiters(handler)
+        self.check_no_message(session)
+        await handler.start()
+        assert handler._reader_ready
 
-#     def check_no_message(self, session):
-#         assert not session.inflight_out
-#         assert not session.inflight_in
+    async def stop_handler(self, handler, session):
+        await handler.stop()
+        assert handler._reader_stopped
+        self.check_empty_waiters(handler)
+        self.check_no_message(session)
 
-#     def test_publish_qos1_retry(self):
-#         async def server_mock(reader, writer) -> None:
-#             packet = await PublishPacket.from_stream(reader)
-#             try:
-#                 assert packet.topic_name == "/topic"
-#                 assert packet.qos == QOS_1
-#                 assert packet.packet_id is not None
-#                 assert packet.packet_id in self.session.inflight_out
-#                 assert self.handler is not None
-#                 assert packet.packet_id in self.handler._puback_waiters
-#                 puback = PubackPacket.build(packet.packet_id)
-#                 await puback.to_stream(writer)
-#             except Exception as ae:
-#                 future.set_exception(ae)
+    def check_empty_waiters(self, handler):
+        assert not handler._puback_waiters
+        assert not handler._pubrec_waiters
+        assert not handler._pubrel_waiters
+        assert not handler._pubcomp_waiters
 
-#         async def test_coro() -> None:
-#             try:
-#                 reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
-#                 reader_adapted, writer_adapted = adapt(reader, writer)
-#                 self.handler = ProtocolHandler(self.plugin_manager)
-#                 self.handler.attach(self.session, reader_adapted, writer_adapted)
-#                 await self.handler.start()
-#                 await self.stop_handler(self.handler, self.session)
-#                 if not future.done():
-#                     future.set_result(True)
-#             except Exception as ae:
-#                 future.set_exception(ae)
+    def check_no_message(self, session):
+        assert not session.inflight_out
+        assert not session.inflight_in
 
-#         self.handler = None
-#         self.session = Session()
-#         message = OutgoingApplicationMessage(1, "/topic", QOS_1, b"test_data", False)
-#         message.publish_packet = PublishPacket.build(
-#             "/topic",
-#             b"test_data",
-#             rand_packet_id(),
-#             False,
-#             QOS_1,
-#             False,
-#         )
-#         self.session.inflight_out[1] = message
-#         future: asyncio.Future[Any] = asyncio.Future()
+    def test_publish_qos1_retry(self):
+        async def server_mock(reader, writer) -> None:
+            packet = await PublishPacket.from_stream(reader)
+            try:
+                assert packet.topic_name == "/topic"
+                assert packet.qos == QOS_1
+                assert packet.packet_id is not None
+                assert packet.packet_id in self.session.inflight_out
+                assert self.handler is not None
+                assert packet.packet_id in self.handler._puback_waiters
+                puback = PubackPacket.build(packet.packet_id)
+                await puback.to_stream(writer)
+            except Exception as ae:
+                future.set_exception(ae)
 
-#         coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
-#         server = self.loop.run_until_complete(coro)
-#         self.loop.run_until_complete(test_coro())
-#         server.close()
-#         self.loop.run_until_complete(server.wait_closed())
-#         exception = future.exception()
-#         if exception:
-#             raise exception
+        async def test_coro() -> None:
+            try:
+                reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
+                reader_adapted, writer_adapted = adapt(reader, writer)
+                self.handler = ProtocolHandler(self.plugin_manager)
+                self.handler.attach(self.session, reader_adapted, writer_adapted)
+                await self.handler.start()
+                await self.stop_handler(self.handler, self.session)
+                if not future.done():
+                    future.set_result(True)
+            except Exception as ae:
+                future.set_exception(ae)
 
-#     def test_publish_qos2_retry(self):
-#         async def server_mock(reader, writer) -> None:
-#             try:
-#                 packet = await PublishPacket.from_stream(reader)
-#                 assert packet.topic_name == "/topic"
-#                 assert packet.qos == QOS_2
-#                 assert packet.packet_id is not None
-#                 assert packet.packet_id in self.session.inflight_out
-#                 assert self.handler is not None
-#                 assert packet.packet_id in self.handler._pubrec_waiters
-#                 pubrec = PubrecPacket.build(packet.packet_id)
-#                 await pubrec.to_stream(writer)
+        self.handler = None
+        self.session = Session()
+        message = OutgoingApplicationMessage(1, "/topic", QOS_1, b"test_data", False)
+        message.publish_packet = PublishPacket.build(
+            "/topic",
+            b"test_data",
+            rand_packet_id(),
+            False,
+            QOS_1,
+            False,
+        )
+        self.session.inflight_out[1] = message
+        future: asyncio.Future[Any] = asyncio.Future()
 
-#                 await PubrelPacket.from_stream(reader)
-#                 assert packet.packet_id in self.handler._pubcomp_waiters
-#                 pubcomp = PubcompPacket.build(packet.packet_id)
-#                 await pubcomp.to_stream(writer)
-#             except Exception as ae:
-#                 future.set_exception(ae)
+        coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
+        server = self.loop.run_until_complete(coro)
+        self.loop.run_until_complete(test_coro())
+        server.close()
+        self.loop.run_until_complete(server.wait_closed())
+        exception = future.exception()
+        if exception:
+            raise exception
 
-#         async def test_coro() -> None:
-#             try:
-#                 reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
-#                 reader_adapted, writer_adapted = adapt(reader, writer)
-#                 self.handler = ProtocolHandler(self.plugin_manager)
-#                 self.handler.attach(self.session, reader_adapted, writer_adapted)
-#                 await self.handler.start()
-#                 await self.stop_handler(self.handler, self.session)
-#                 if not future.done():
-#                     future.set_result(True)
-#             except Exception as ae:
-#                 future.set_exception(ae)
+    def test_publish_qos2_retry(self):
+        async def server_mock(reader, writer) -> None:
+            try:
+                packet = await PublishPacket.from_stream(reader)
+                assert packet.topic_name == "/topic"
+                assert packet.qos == QOS_2
+                assert packet.packet_id is not None
+                assert packet.packet_id in self.session.inflight_out
+                assert self.handler is not None
+                assert packet.packet_id in self.handler._pubrec_waiters
+                pubrec = PubrecPacket.build(packet.packet_id)
+                await pubrec.to_stream(writer)
 
-#         self.handler = None
-#         self.session = Session()
-#         message = OutgoingApplicationMessage(1, "/topic", QOS_2, b"test_data", False)
-#         message.publish_packet = PublishPacket.build(
-#             "/topic",
-#             b"test_data",
-#             rand_packet_id(),
-#             False,
-#             QOS_2,
-#             False,
-#         )
-#         self.session.inflight_out[1] = message
-#         future: asyncio.Future[Any] = asyncio.Future()
+                await PubrelPacket.from_stream(reader)
+                assert packet.packet_id in self.handler._pubcomp_waiters
+                pubcomp = PubcompPacket.build(packet.packet_id)
+                await pubcomp.to_stream(writer)
+            except Exception as ae:
+                future.set_exception(ae)
 
-#         coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
-#         server = self.loop.run_until_complete(coro)
-#         self.loop.run_until_complete(test_coro())
-#         server.close()
-#         self.loop.run_until_complete(server.wait_closed())
-#         exception = future.exception()
-#         if exception:
-#             raise exception
+        async def test_coro() -> None:
+            try:
+                reader, writer = await asyncio.open_connection("127.0.0.1", 8888)
+                reader_adapted, writer_adapted = adapt(reader, writer)
+                self.handler = ProtocolHandler(self.plugin_manager)
+                self.handler.attach(self.session, reader_adapted, writer_adapted)
+                await self.handler.start()
+                await self.stop_handler(self.handler, self.session)
+                if not future.done():
+                    future.set_result(True)
+            except Exception as ae:
+                future.set_exception(ae)
+
+        self.handler = None
+        self.session = Session()
+        message = OutgoingApplicationMessage(1, "/topic", QOS_2, b"test_data", False)
+        message.publish_packet = PublishPacket.build(
+            "/topic",
+            b"test_data",
+            rand_packet_id(),
+            False,
+            QOS_2,
+            False,
+        )
+        self.session.inflight_out[1] = message
+        future: asyncio.Future[Any] = asyncio.Future()
+
+        coro = asyncio.start_server(server_mock, "127.0.0.1", 8888)
+        server = self.loop.run_until_complete(coro)
+        self.loop.run_until_complete(test_coro())
+        server.close()
+        self.loop.run_until_complete(server.wait_closed())
+        exception = future.exception()
+        if exception:
+            raise exception

--- a/tests/mqtt/protocol/test_handler.py
+++ b/tests/mqtt/protocol/test_handler.py
@@ -46,7 +46,8 @@ class ProtocolHandlerTest(unittest.TestCase):
 
     def test_start_stop(self):
         async def server_mock(reader, writer) -> None:
-            pass
+            writer.close()  # python 3.12 requires an explicit close
+            await writer.wait_closed()
 
         async def test_coro() -> None:
             try:
@@ -78,6 +79,9 @@ class ProtocolHandlerTest(unittest.TestCase):
                 assert packet.variable_header.topic_name == "/topic"
                 assert packet.qos == QOS_0
                 assert packet.packet_id is None
+                writer.close()  # python 3.12 requires an explicit close
+                await writer.wait_closed()
+
             except Exception as ae:
                 future.set_exception(ae)
 
@@ -130,6 +134,8 @@ class ProtocolHandlerTest(unittest.TestCase):
                 assert packet.packet_id in self.handler._puback_waiters
                 puback = PubackPacket.build(packet.packet_id)
                 await puback.to_stream(writer)
+                writer.close()  # python 3.12 requires an explicit close
+                await writer.wait_closed()
             except Exception as ae:
                 future.set_exception(ae)
 
@@ -188,6 +194,8 @@ class ProtocolHandlerTest(unittest.TestCase):
                 assert packet.packet_id in self.handler._pubcomp_waiters
                 pubcomp = PubcompPacket.build(packet.packet_id)
                 await pubcomp.to_stream(writer)
+                writer.close()  # python 3.12 requires an explicit close
+                await writer.wait_closed()
             except Exception as ae:
                 future.set_exception(ae)
 
@@ -240,6 +248,8 @@ class ProtocolHandlerTest(unittest.TestCase):
                 False,
             )
             await packet.to_stream(writer)
+            writer.close()  # python 3.12 requires an explicit close
+            await writer.wait_closed()
 
         async def test_coro() -> None:
             try:
@@ -257,6 +267,7 @@ class ProtocolHandlerTest(unittest.TestCase):
                 assert message.pubcomp_packet is None
                 await self.stop_handler(self.handler, self.session)
                 future.set_result(True)
+
             except Exception as ae:
                 future.set_exception(ae)
 
@@ -287,6 +298,8 @@ class ProtocolHandlerTest(unittest.TestCase):
                 puback = await PubackPacket.from_stream(reader)
                 assert puback is not None
                 assert packet.packet_id == puback.packet_id
+                writer.close()  # python 3.12 requires an explicit close
+                await writer.wait_closed()
             except Exception as ae:
                 future.set_exception(ae)
 
@@ -344,6 +357,8 @@ class ProtocolHandlerTest(unittest.TestCase):
                 pubcomp = await PubcompPacket.from_stream(reader)
                 assert pubcomp is not None
                 assert packet.packet_id == pubcomp.packet_id
+                writer.close()  # python 3.12 requires an explicit close
+                await writer.wait_closed()
             except Exception as ae:
                 future.set_exception(ae)
 
@@ -412,6 +427,8 @@ class ProtocolHandlerTest(unittest.TestCase):
                 assert packet.packet_id in self.handler._puback_waiters
                 puback = PubackPacket.build(packet.packet_id)
                 await puback.to_stream(writer)
+                writer.close()  # python 3.12 requires an explicit close
+                await writer.wait_closed()
             except Exception as ae:
                 future.set_exception(ae)
 
@@ -468,6 +485,9 @@ class ProtocolHandlerTest(unittest.TestCase):
                 assert packet.packet_id in self.handler._pubcomp_waiters
                 pubcomp = PubcompPacket.build(packet.packet_id)
                 await pubcomp.to_stream(writer)
+                writer.close()  # python 3.12 requires an explicit close
+                await writer.wait_closed()
+
             except Exception as ae:
                 future.set_exception(ae)
 

--- a/tests/mqtt/protocol/test_handler.py
+++ b/tests/mqtt/protocol/test_handler.py
@@ -38,11 +38,23 @@ class ProtocolHandlerTest(unittest.TestCase):
         self.loop.close()
 
     def test_init_handler(self):
-        Session()
-        handler = ProtocolHandler(self.plugin_manager, loop=self.loop)
-        assert handler.session is None
-        assert handler._loop is self.loop
-        self.check_empty_waiters(handler)
+
+        async def test_coro() -> None:
+            try:
+                Session()
+                handler = ProtocolHandler(self.plugin_manager)
+                assert handler.session is None
+                assert handler._loop is self.loop
+                self.check_empty_waiters(handler)
+                future.set_result(True)
+            except Exception as ae:
+                future.set_exception(ae)
+
+        future: asyncio.Future[Any] = asyncio.Future()
+        self.loop.run_until_complete(test_coro())
+        exception = future.exception()
+        if exception:
+            raise exception
 
     def test_start_stop(self):
         async def server_mock(reader, writer) -> None:


### PR DESCRIPTION
# Summary

`test_handler.py` tests cases of QoS 1 & 2 were all timing out waiting for their respective acknowledgement packets. The mock server was sending them but never able to be read for the protocol handler's reader loop because the timeout for the read was being set to zero, which caused a repeated exception and never allowing the data to enter the stream (presumably).

# What Changed

- `_reader_loop` gets it's read timeout (keepalive) from the sesion and there is a check to make sure that the session has a valid number and is greater than zero. keep alive was being set to zero and over the python version changes, checking for None now needs to be explicit (`if keepalive` vs `if keepalive is not None`). if keepalive (the default value in the session was 0 so the timeout  was being set to zero instead of None, which allows waiting to read from the stream, instead of immediately timingout

- a [bug in python 3.12.0](https://github.com/python/cpython/issues/104344?utm_source=chatgpt.com) highlighted the need to explicitly close the `asyncio.start_server` by closing the writer stream. This happens to be true for all versions of python 3.10+ but only 3.12 seems to have an issue when it's not done explicitly.

- the ProtocolHandler gets it's loop from the current running loop. however, we need to run the protocolhandler in that loop in order to check to make sure it defaultly gets the correct loop and not the main loop.


# Testing

-- added back in the `test_handler.py` files for checking the qos acknowledgement flows and verified they pass correctly.


( it will be easier to see the specific changes for this when the python3.10 pull request is reviewed )


