### PR TITLE
fixes Yakifo/amqtt#159 :  'will' topic docs and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: uv sync --locked --dev
 
       - name: Run pytest
-        run: uv run --frozen pytest tests --cov=./ --cov-report=xml --junitxml=pytest-report.xml
+        run: uv run --frozen pytest tests/ --cov=./ --cov-report=xml --junitxml=pytest-report.xml
 
       # https://github.com/actions/upload-artifact
       - name: Upload test report

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,6 @@ repos:
     hooks:
       - id: ruff
         args:
-          - --fix
-          - --unsafe-fixes
           - --line-length=130
           - --exit-non-zero-on-fix
 

--- a/amqtt/client.py
+++ b/amqtt/client.py
@@ -156,7 +156,7 @@ class MQTTClient:
             msg = "Future or Task was cancelled"
             raise ConnectError(msg) from e
         except Exception as e:
-            self.logger.warning(f"Connection failed: {e}")
+            self.logger.warning(f"Connection failed: {e!r}")
             if not self.config.get("auto_reconnect", False):
                 raise
             return await self.reconnect()
@@ -230,9 +230,11 @@ class MQTTClient:
                 msg = "Future or Task was cancelled"
                 raise ConnectError(msg) from e
             except Exception as e:
-                self.logger.warning(f"Reconnection attempt failed: {e}", exc_info=True)
+                self.logger.warning(f"Reconnection attempt failed: {e!r}")
+                self.logger.debug("", exc_info=True)
                 if reconnect_retries < nb_attempt:  # reconnect_retries >= 0 and
                     self.logger.exception("Maximum connection attempts reached. Reconnection aborted.")
+                    self.logger.debug("", exc_info=True)
                     msg = "Too many failed attempts"
                     raise ConnectError(msg) from e
                 delay = min(reconnect_max_interval, 2**nb_attempt)
@@ -475,6 +477,7 @@ class MQTTClient:
                     self.session.remote_port,
                     **kwargs,
                 )
+
                 reader = StreamReaderAdapter(conn_reader)
                 writer = StreamWriterAdapter(conn_writer)
             elif scheme in ("ws", "wss") and self.session.broker_uri:
@@ -511,7 +514,7 @@ class MQTTClient:
             self.logger.debug(f"Connected to {self.session.remote_address}:{self.session.remote_port}")
 
         except (InvalidURI, InvalidHandshake, ProtocolHandlerError, ConnectionError, OSError) as e:
-            self.logger.warning(f"Connection failed : {self.session.broker_uri} : {e}")
+            self.logger.debug(f"Connection failed : {self.session.broker_uri} [{e!r}]")
             self.session.transitions.disconnect()
             raise ConnectError(e) from e
         return return_code

--- a/amqtt/client.py
+++ b/amqtt/client.py
@@ -148,7 +148,7 @@ class MQTTClient:
         additional_headers = additional_headers if additional_headers is not None else {}
         self.session = self._init_session(uri, cleansession, cafile, capath, cadata)
         self.additional_headers = additional_headers
-        self.logger.debug(f"Connecting to: {uri}")
+        self.logger.debug(f"Connecting to: {self.session.broker_uri}")
 
         try:
             return await self._do_connect()
@@ -230,7 +230,7 @@ class MQTTClient:
                 msg = "Future or Task was cancelled"
                 raise ConnectError(msg) from e
             except Exception as e:
-                self.logger.warning(f"Reconnection attempt failed: {e}")
+                self.logger.warning(f"Reconnection attempt failed: {e}", exc_info=True)
                 if reconnect_retries < nb_attempt:  # reconnect_retries >= 0 and
                     self.logger.exception("Maximum connection attempts reached. Reconnection aborted.")
                     msg = "Too many failed attempts"
@@ -594,7 +594,7 @@ class MQTTClient:
             session.will_flag = True
             session.will_retain = self.config["will"]["retain"]
             session.will_topic = self.config["will"]["topic"]
-            session.will_message = self.config["will"]["message"]
+            session.will_message = self.config["will"]["message"].encode()
             session.will_qos = self.config["will"]["qos"]
 
         return session

--- a/amqtt/plugins/manager.py
+++ b/amqtt/plugins/manager.py
@@ -87,7 +87,8 @@ class PluginManager:
             obj = plugin(plugin_context)
             return Plugin(ep.name, ep, obj)
         except ImportError:
-            self.logger.warning(f"Plugin {ep!r} import failed", exc_info=True)
+            self.logger.warning(f"Plugin {ep!r} import failed")
+            self.logger.debug("", exc_info=True)
 
         return None
 

--- a/amqtt/scripts/pub_script.py
+++ b/amqtt/scripts/pub_script.py
@@ -133,7 +133,7 @@ def _version(v: bool) -> None:
 
 @app.command()
 def publisher_main(  # pylint: disable=R0914,R0917  # noqa : PLR0913
-    url: str | None = typer.Option(None, "--url", help="Broker connection URL, *must conform to MQTT URI scheme: `mqtt://<username:password>@HOST:port`*"),
+    url: str | None = typer.Option(None, "--url", help="Broker connection URL, *must conform to MQTT or URI scheme: `[mqtt(s)|ws(s)]://<username:password>@HOST:port`*"),
     config_file: str | None = typer.Option(None, "-c", "--config-file", help="Client configuration file"),
     client_id: str | None = typer.Option(None, "-i", "--client-id", help="client identification for mqtt connection. *default: process id and the hostname of the client*"),
     qos: int = typer.Option(0, "--qos", "-q", help="Quality of service (0, 1, or 2)"),

--- a/amqtt/scripts/pub_script.py
+++ b/amqtt/scripts/pub_script.py
@@ -112,7 +112,7 @@ async def do_pub(
         await client.disconnect()
         logger.info(f"{client.client_id} Disconnected from broker")
     except ConnectError as ce:
-        logger.fatal(f"Connection to '{url}' failed: {ce!r}")
+        logger.fatal(f"Connection to '{client.session.broker_uri if client.session else url}' failed")
         raise ConnectError from ce
     except asyncio.CancelledError as ce:
         logger.fatal("Publish canceled due to previous error")

--- a/amqtt/scripts/sub_script.py
+++ b/amqtt/scripts/sub_script.py
@@ -108,7 +108,7 @@ def _version(v:bool) -> None:
 
 @app.command()
 def subscribe_main(  # pylint: disable=R0914,R0917  # noqa : PLR0913
-    url: str = typer.Option(None, help="Broker connection URL, *must conform to MQTT URI scheme: `mqtt://<username:password>@HOST:port`*", show_default=False),
+    url: str = typer.Option(None, help="Broker connection URL, *must conform to MQTT or URI scheme: `[mqtt(s)|ws(s)]://<username:password>@HOST:port`*", show_default=False),
     config_file: str | None = typer.Option(None, "-c", help="Client configuration file"),
     client_id: str | None = typer.Option(None, "-i", help="client identification for mqtt connection. *default: process id and the hostname of the client*"),
     max_count: int | None = typer.Option(None, "-n", help="Number of messages to read before ending *default: read indefinitely*"),

--- a/amqtt/scripts/sub_script.py
+++ b/amqtt/scripts/sub_script.py
@@ -108,7 +108,7 @@ def _version(v:bool) -> None:
 
 @app.command()
 def subscribe_main(  # pylint: disable=R0914,R0917  # noqa : PLR0913
-    url: str = typer.Option(..., help="Broker connection URL, *must conform to MQTT URI scheme: `mqtt://<username:password>@HOST:port`*", show_default=False),
+    url: str = typer.Option(None, help="Broker connection URL, *must conform to MQTT URI scheme: `mqtt://<username:password>@HOST:port`*", show_default=False),
     config_file: str | None = typer.Option(None, "-c", help="Client configuration file"),
     client_id: str | None = typer.Option(None, "-i", help="client identification for mqtt connection. *default: process id and the hostname of the client*"),
     max_count: int | None = typer.Option(None, "-n", help="Number of messages to read before ending *default: read indefinitely*"),
@@ -162,7 +162,7 @@ def subscribe_main(  # pylint: disable=R0914,R0917  # noqa : PLR0913
     if will_topic and will_message:
         config["will"] = {
             "topic": will_topic,
-            "message": will_message.encode("utf-8"),
+            "message": will_message,
             "qos": int(will_qos),
             "retain": will_retain,
         }

--- a/docs/references/client_config.md
+++ b/docs/references/client_config.md
@@ -33,6 +33,10 @@ Maximum reconnection retries. Defaults to `2`. Negative value will cause client 
 
 Maximum interval between 2 connection retry. Defaults to `10`.
 
+### `cleansession` *(bool)*
+
+Upon reconnect, should subscriptions be cleared. Defaults to `true`.
+
 ### `topics` *(list[mapping])*
 
 Specify the topics and what flags should be set for messages published to them.
@@ -40,6 +44,27 @@ Specify the topics and what flags should be set for messages published to them.
 - `<topic>`: Named listener
     - `qos` *(int, 0-3)*: 
     - `retain` *(bool)*: 
+
+### `will` *(mapping)*
+
+If included, the message that should be sent if the client disconnects.
+
+- `topic` *(string)*:
+- `message` *(string)*:
+- `qos` *(int): 0, 1 or 2
+- `retain`: *(bool)* new clients subscribing to `topic` will receive this message
+
+### `broker` *(mapping)*
+
+- `uri` *(string)*: Broker connection URL, *must conform to MQTT or URI scheme: `[mqtt(s)|ws(s)]://<username:password>@HOST:port`*
+
+TLS certificates used to verify the broker's authenticity.
+
+- `cafile` *(string)*:  Path to a file of concatenated CA certificates in PEM format. See [Certificates](https://docs.python.org/3/library/ssl.html#ssl-certificates) for more info.
+- `capath` *(string)*:  Path to a directory containing several CA certificates in PEM format, following an [OpenSSL specific layout](https://docs.openssl.org/master/man3/SSL_CTX_load_verify_locations/).
+- `cadata` *(string)*:  Either an ASCII string of one or more PEM-encoded certificates or a bytes-like object of DER-encoded certificates.
+
+
 
 
 ## Default Configuration
@@ -54,10 +79,10 @@ Specify the topics and what flags should be set for messages published to them.
 
 keep_alive: 10
 ping_delay: 1
-default_qos': 0
+default_qos: 0
 default_retain: false
 auto_reconnect: true
-reconnect_max_interval: 5,
+reconnect_max_interval: 5
 reconnect_retries: 10
 topics:
    test:
@@ -65,4 +90,12 @@ topics:
    some_topic:
      qos: 2
      retain: true
+will:
+   topic: will/messages
+   message: "client ABC has disconnected"
+   qos: 1
+   retain: false
+broker:
+   uri: mqtt://localhost:1883
+   cafile: /path/to/ca/file
 ```

--- a/docs/references/client_config.md
+++ b/docs/references/client_config.md
@@ -60,9 +60,9 @@ auto_reconnect: true
 reconnect_max_interval: 5,
 reconnect_retries: 10
 topics:
-   - test:
-       qos: 0
-   - some_topic:
-       qos: 2
-       retain: true
+   test:
+    qos: 0
+   some_topic:
+     qos: 2
+     retain: true
 ```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,7 @@ async def broker(broker_config_file):
     proc.wait()
 
 
+@pytest.mark.timeout(12)
 def test_cli_help_messages():
     """Test that help messages are displayed correctly."""
     env = os.environ.copy()
@@ -78,7 +79,7 @@ def test_cli_help_messages():
     output = subprocess.check_output([amqtt_pub_path, "--help"], env=env, text=True)
     assert "Usage: amqtt_pub" in output
 
-
+@pytest.mark.timeout(12)
 def test_broker_version():
     """Test broker version command."""
     output = subprocess.check_output(["amqtt", "--version"])
@@ -86,6 +87,7 @@ def test_broker_version():
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(12)
 async def test_broker_start_stop(broker_config_file):
     """Test broker start and stop with config file."""
     proc = subprocess.Popen(
@@ -107,6 +109,7 @@ async def test_broker_start_stop(broker_config_file):
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(12)
 async def test_publish_subscribe(broker):
     """Test pub/sub CLI tools with running broker."""
 
@@ -159,6 +162,7 @@ async def test_publish_subscribe(broker):
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(12)
 async def test_pub_sub_retain(broker):
     """Test various pub/sub will retain options."""
     # Test publishing with retain flag
@@ -191,6 +195,7 @@ async def test_pub_sub_retain(broker):
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(12)
 async def test_pub_errors():
     """Test error handling in pub/sub tools."""
     # Test connection to non-existent broker
@@ -208,6 +213,7 @@ async def test_pub_errors():
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(12)
 async def test_sub_errors():
     # Test invalid URL format
     sub_proc = subprocess.run(
@@ -260,6 +266,7 @@ def client_config_file(client_config, tmp_path):
     return str(config_path)
 
 
+@pytest.mark.timeout(12)
 def test_pub_client_config(broker, client_config_file):
     pub_proc = subprocess.run(
         [
@@ -274,6 +281,7 @@ def test_pub_client_config(broker, client_config_file):
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(12)
 async def test_pub_client_config_will(broker, client_config, client_config_file):
 
     # verifying client script functionality of will topic (publisher)
@@ -302,6 +310,7 @@ async def test_pub_client_config_will(broker, client_config, client_config_file)
     await client1.disconnect()
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(12)
 async def test_sub_client_config_will(broker, client_config_file):
 
     # verifying client script functionality of will topic (subscriber)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,6 @@ import os
 import signal
 import subprocess
 import tempfile
-from asyncio import timeout
 
 import pytest
 import yaml

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -264,6 +264,8 @@ def client_config():
     }
 
 
+@pytest.mark.asyncio
+@pytest.mark.timeout(12)
 async def test_client_publish_will_with_retain(broker_fixture, client_config):
 
     # verifying client functionality of will topic

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -265,7 +265,6 @@ def client_config():
 
 
 @pytest.mark.asyncio
-@pytest.mark.timeout(12)
 async def test_client_publish_will_with_retain(broker_fixture, client_config):
 
     # verifying client functionality of will topic

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -231,3 +231,66 @@ async def test_cancel_publish_qos2_pubcomp(broker_fixture):
 
     await asyncio.sleep(0.1)
     await client_pub.disconnect()
+
+
+@pytest.fixture
+def client_config():
+    return {
+        "default_retain": False,
+        "topics": {
+                "test": {
+                    "qos": 0
+                },
+                "some_topic": {
+                    "retain": True,
+                    "qos": 2
+                }
+        },
+        "keep_alive": 10,
+        "broker": {
+            "uri": "mqtt://localhost:1884"
+        },
+        "reconnect_max_interval": 5,
+        "will": {
+            "topic": "test/will/topic",
+            "retain": True,
+            "message": "client ABC has disconnected",
+            "qos": 1
+        },
+        "ping_delay": 1,
+        "default_qos": 0,
+        "auto_reconnect": True,
+        "reconnect_retries": 10
+    }
+
+
+async def test_client_publish_will_with_retain(broker_fixture, client_config):
+
+    # verifying client functionality of will topic
+    # https://github.com/Yakifo/amqtt/issues/159
+
+    client1 = MQTTClient(client_id="client1")
+    await client1.connect('mqtt://localhost:1883')
+    await  client1.subscribe([
+        ("test/will/topic", QOS_0)
+        ])
+
+    client2 = MQTTClient(client_id="client2", config=client_config)
+    await client2.connect('mqtt://localhost:1883')
+    await client2.publish('my/topic', b'my message')
+    await client2.disconnect()
+
+    message = await client1.deliver_message(timeout_duration=1)
+    assert message.topic == 'test/will/topic'
+    assert message.data == b'client ABC has disconnected'
+    await client1.disconnect()
+
+    client3 = MQTTClient(client_id="client3")
+    await client3.connect('mqtt://localhost:1883')
+    await client3.subscribe([
+        ("test/will/topic", QOS_0)
+    ])
+    message3 = await client3.deliver_message(timeout_duration=1)
+    assert message3.topic == 'test/will/topic'
+    assert message3.data == b'client ABC has disconnected'
+    await client3.disconnect()


### PR DESCRIPTION
# Summary

When a client connects, it can specify a 'will' message which will be issued if the client disconnects. There are command line options for `amqtt_sub` and `amqtt_pub` but no documentation on how to set these via the client config.

# What Changed

- added documentation to client config:
    - 'will' section for specifying topic, message, qos and retain 
    - 'broker' section for specifying options to connect to the broker

# Tests
added tests to verify that 'will' config is working for `MQTTClient` as well as for the `amqtt_pub` and `amqtt_sub` scripts
