### PR TITLE
add `ruff` to ci.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
         run: uv run --frozen mypy ${{ env.PROJECT_PATH }}/
       - name: Pylint review
         run: uv run --frozen pylint ${{ env.PROJECT_PATH }}/
+      - name: Ruff check
+        run: uv run --frozen ruff check ${{ env.PROJECT_PATH }}/
 
   tests:
     name: Run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,6 @@ repos:
     hooks:
       - id: ruff
         args:
-          - --fix
-          - --unsafe-fixes
           - --line-length=130
           - --exit-non-zero-on-fix
 


### PR DESCRIPTION
# Summary

the pre-commit checks use mypy, ruff and pylint. in order to make sure this is enforced, also run `ruff check` for pull requests.

pre-commit checks should just _check_ and not modify the code. the `fix` options are removed from the `pre-commit`