### PR TITLE
fixes #116 : adding reason message to task cancellation on lost connection

### DIFF
--- a/amqtt/client.py
+++ b/amqtt/client.py
@@ -533,7 +533,7 @@ class MQTTClient:
             while self.client_tasks:
                 task = self.client_tasks.popleft()
                 if not task.done():
-                    task.cancel()
+                    task.cancel(msg="Connection closed.")
 
         self.logger.debug("Monitoring broker disconnection")
         # Wait for disconnection from broker (like connection lost)


### PR DESCRIPTION
`set_exception` was already replaced with `cancel`

adding reason message to task cancellation on lost connection