### PR TITLE
fixes Yakifo/amqtt#154 : will message is allowed to have zero length

### DIFF
--- a/amqtt/errors.py
+++ b/amqtt/errors.py
@@ -13,6 +13,9 @@ class CodecError(Exception):
 class NoDataError(Exception):
     """Exceptions thrown by packet encode/decode functions."""
 
+class ZeroLengthReadError(NoDataError):
+    def __init__(self) -> None:
+        super().__init__("Decoding a string of length zero.")
 
 class BrokerError(Exception):
     """Exceptions thrown by broker."""


### PR DESCRIPTION
# Summary

From [MQTT 3.1.1 Connect](https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#connect)

> Will Message
> If the Will Flag is set, this is the next UTF-8 encoded string. The Will Message defines the content of the message
>  that is published to the Will Topic if the client is unexpectedly disconnected. This may be a zero-length message.

Also, [reading from a stream](https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamReader.read) with a length of zero is valid and will return bytes of length zero (as opposed to reading when there's no data which should return 'None').

# Changes

- when reading from a stream, differentiate between an empty bytearray and `None`. The former should return an empty byte array, the latter should raise a `NoDataError`
- in the cases where we are reading the value in order to determine the length of string we should read, the code relies on this raising a `NoDataError` so handle this case when trying to decode a string
- Creating exception class to satisfy EM101 and TRY003 (ZeroReadLengthError)

# Teset

- add test to confirm failure / fix of this issue