### PR TITLE
docker container for amqtt

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ $ pip install amqtt
 
 Available on [Read the Docs](http://amqtt.readthedocs.org/).
 
+## Containerization
+
+Launch from [DockerHub](https://hub.docker.com/repository/docker/amqtt/amqtt)
+
+```shell
+$ docker run -d -p 1883:1883 amqtt/amqtt:latest
+```
+
 ## Support
 
 Bug reports, patches and suggestions welcome! Just [open an issue](https://github.com/Yakifo/amqtt/issues/new) or join the [gitter community](https://gitter.im/amqtt/community).

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.13-alpine
+
+WORKDIR /app
+COPY . /app
+
+RUN pip install --upgrade uv
+RUN uv pip install --system --no-cache .
+
+COPY ./amqtt/scripts/default_broker.yaml /app/config/broker.yaml
+
+EXPOSE 1883
+
+# Run app.py when the container launches
+CMD ["amqtt", "-c", "/app/config/broker.yaml"]

--- a/dockerfile
+++ b/dockerfile
@@ -1,14 +1,27 @@
+
+# -- build stage, install dependencies only using `uv`
+FROM python:3.13-alpine AS build
+
+RUN pip install uv
+
+WORKDIR /app
+
+COPY . /app
+RUN uv pip install --target=/deps .
+
+
+# -- final image, copy dependencies and amqtt source
 FROM python:3.13-alpine
 
 WORKDIR /app
-COPY . /app
 
-RUN pip install --upgrade uv
-RUN uv pip install --system --no-cache .
+COPY --from=build /deps /usr/local/lib/python3.13/site-packages/
 
-COPY ./amqtt/scripts/default_broker.yaml /app/config/broker.yaml
+COPY ./amqtt/scripts/default_broker.yaml /app/conf/broker.yaml
 
 EXPOSE 1883
 
-# Run app.py when the container launches
-CMD ["amqtt", "-c", "/app/config/broker.yaml"]
+ENV PATH="/usr/local/lib/python3.13/site-packages/bin:$PATH"
+
+# Run `amqtt` when the container launches
+CMD ["amqtt", "-c", "/app/conf/broker.yaml"]

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,38 @@
+# Containerization
+
+Built from [dockerfile](https://github.com/Yakifo/amqtt/blob/main/dockerfile), the default `aMQTT` broker is publicly available on [DockerHub](https://hub.docker.com/repository/docker/amqtt/amqtt).
+
+## Launch
+
+```shell
+$ docker run -d -p 1883:1883 amqtt/amqtt:latest
+```
+
+## Configure and launch
+
+The easiest way to provide a custom [aMQTT broker configuration](references/broker_config.md),
+is to create a yaml file...
+
+```shell
+$ cp amqtt/scripts/default_broker.yaml broker.yaml
+```
+
+and create a docker compose file...
+
+```yaml
+services:
+  amqtt:
+    image: amqtt
+    container_name: amqtt
+    ports:
+      - "1883:1883"
+    volumes:
+      - ./broker.yaml:/app/conf/broker.yaml
+```
+
+and launch with...
+
+```shell
+$ docker compose -d -f docker-compose.yaml up
+```
+

--- a/docs/references/amqtt.md
+++ b/docs/references/amqtt.md
@@ -10,7 +10,7 @@
 Without the `-c` argument, the broker will run with the following, default configuration:
 
 ```yaml
---8<-- "../amqtt/amqtt/scripts/default_broker.yaml"
+--8<-- "amqtt/scripts/default_broker.yaml"
 ```
 
 Using the `-c` argument allows for configuration with a YAML structured file; see [broker configuration](broker_config.md). 

--- a/docs/references/amqtt_pub.md
+++ b/docs/references/amqtt_pub.md
@@ -10,7 +10,7 @@
 Without the `-c` argument, the client will run with the following, default configuration:
 
 ```yaml
---8<-- "../amqtt/amqtt/scripts/default_client.yaml"
+--8<-- "amqtt/scripts/default_client.yaml"
 ```
 
 Using the `-c` argument allows for configuration with a YAML structured file; see [client configuration](client_config.md). 

--- a/docs/references/amqtt_sub.md
+++ b/docs/references/amqtt_sub.md
@@ -10,7 +10,7 @@
 Without the `-c` argument, the client will run with the following, default configuration:
 
 ```yaml
---8<-- "../amqtt/amqtt/scripts/default_client.yaml"
+--8<-- "amqtt/scripts/default_client.yaml"
 ```
 
 Using the `-c` argument allows for configuration with a YAML structured file; see [client configuration](client_config.md). 

--- a/docs/references/broker.md
+++ b/docs/references/broker.md
@@ -7,7 +7,7 @@ The `amqtt.broker.Broker` class provides a complete MQTT 3.1.1 broker implementa
 The following example shows how to start a broker using the default configuration:
 
 ```python
---8<-- "../amqtt/samples/broker_simple.py"
+--8<-- "samples/broker_simple.py"
 ```
 
 This will start the broker and let it run until it is shutdown by `^c`.

--- a/docs/references/broker_config.md
+++ b/docs/references/broker_config.md
@@ -97,7 +97,7 @@ Configuration for access control policies for publishing and subscribing to topi
 ## Default Configuration
 
 ```yaml
---8<-- "../amqtt/amqtt/scripts/default_broker.yaml"
+--8<-- "amqtt/scripts/default_broker.yaml"
 ```
 
 ## Example

--- a/docs/references/client_config.md
+++ b/docs/references/client_config.md
@@ -70,7 +70,7 @@ TLS certificates used to verify the broker's authenticity.
 ## Default Configuration
 
 ```yaml
---8<-- "../amqtt/amqtt/scripts/default_client.yaml"
+--8<-- "amqtt/scripts/default_client.yaml"
 ```
 
 ## Example

--- a/mkdocs.rtd.yml
+++ b/mkdocs.rtd.yml
@@ -17,7 +17,7 @@ watch:
   - docs
   - amqtt
   - samples
-copyright: TBD
+copyright: '2025'
 edit_uri: edit/main/docs/
 
 validation:
@@ -44,6 +44,7 @@ nav:
           - Broker: references/broker_config.md
           - Client: references/client_config.md
       - Reference:
+          - Containerization: docker.md
           - Support: support.md
           - Contributing: contributing.md
           - Change log: changelog.md
@@ -119,6 +120,7 @@ markdown_extensions:
 plugins:
   - search
   - autorefs
+  - open-in-new-tab
   - markdown-exec
   - section-index
   - coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,8 @@ docs = [
     "mkdocstrings-python>=1.16.2",
     # YORE: EOL 3.10: Remove line.
     "tomli>=2.0; python_version < '3.11'",
-    "mkdocs-typer2>=0.1.4"
+    "mkdocs-typer2>=0.1.4",
+    "mkdocs-open-in-new-tab>=1.0.8",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,7 @@ docs = [
     { name = "mkdocs-llmstxt" },
     { name = "mkdocs-material" },
     { name = "mkdocs-minify-plugin" },
+    { name = "mkdocs-open-in-new-tab" },
     { name = "mkdocs-redirects" },
     { name = "mkdocs-section-index" },
     { name = "mkdocs-typer2" },
@@ -102,6 +103,7 @@ docs = [
     { name = "mkdocs-llmstxt", specifier = ">=0.1" },
     { name = "mkdocs-material", specifier = ">=9.5" },
     { name = "mkdocs-minify-plugin", specifier = ">=0.8" },
+    { name = "mkdocs-open-in-new-tab", specifier = ">=1.0.8" },
     { name = "mkdocs-redirects", specifier = ">=1.2.1" },
     { name = "mkdocs-section-index", specifier = ">=0.3" },
     { name = "mkdocs-typer2", specifier = ">=0.1.4" },
@@ -1110,6 +1112,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/67/fe4b77e7a8ae7628392e28b14122588beaf6078b53eb91c7ed000fd158ac/mkdocs-minify-plugin-0.8.0.tar.gz", hash = "sha256:bc11b78b8120d79e817308e2b11539d790d21445eb63df831e393f76e52e753d", size = 8366, upload-time = "2024-01-29T16:11:32.982Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/cd/2e8d0d92421916e2ea4ff97f10a544a9bd5588eb747556701c983581df13/mkdocs_minify_plugin-0.8.0-py3-none-any.whl", hash = "sha256:5fba1a3f7bd9a2142c9954a6559a57e946587b21f133165ece30ea145c66aee6", size = 6723, upload-time = "2024-01-29T16:11:31.851Z" },
+]
+
+[[package]]
+name = "mkdocs-open-in-new-tab"
+version = "1.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/0e/f72a506a21bdb27b807124e00c688226848a388d1fd3980b80ae3cc27203/mkdocs_open_in_new_tab-1.0.8.tar.gz", hash = "sha256:3e0dad08cc9938b0b13097be8e0aa435919de1eeb2d1a648e66b5dee8d57e048", size = 5791, upload-time = "2024-11-18T13:15:13.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/94/44f3c868495481c868d08eea065c82803f1affd8553d3383b782f497613c/mkdocs_open_in_new_tab-1.0.8-py3-none-any.whl", hash = "sha256:051d767a4467b12d89827e1fea0ec660b05b027c726317fe4fceee5456e36ad2", size = 7717, upload-time = "2024-11-18T13:15:12.286Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary

Enable users to easily try the aMQTT broker by providing a docker image.

# What Changed

- added `dockerfile` to build
- added documentation on how to use the docker image
- fixed paths for snippet links
