### PR TITLE
fixes amqtt/Yakifo#210 : 

### DIFF
--- a/amqtt/mqtt/protocol/client_handler.py
+++ b/amqtt/mqtt/protocol/client_handler.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import Any
 
-from amqtt.errors import AMQTTError
+from amqtt.errors import AMQTTError, NoDataError
 from amqtt.mqtt.connack import ConnackPacket
 from amqtt.mqtt.connect import ConnectPacket, ConnectPayload, ConnectVariableHeader
 from amqtt.mqtt.disconnect import DisconnectPacket
@@ -87,8 +87,10 @@ class ClientProtocolHandler(ProtocolHandler):
         if self.reader is None:
             msg = "Reader is not initialized."
             raise AMQTTError(msg)
-
-        connack = await ConnackPacket.from_stream(self.reader)
+        try:
+            connack = await ConnackPacket.from_stream(self.reader)
+        except NoDataError as e:
+            raise ConnectionError from e
         await self.plugins_manager.fire_event(EVENT_MQTT_PACKET_RECEIVED, packet=connack, session=self.session)
         return connack.return_code
 

--- a/tests/plugins/mocks.py
+++ b/tests/plugins/mocks.py
@@ -1,0 +1,18 @@
+import logging
+
+from amqtt.plugins.authentication import BaseAuthPlugin
+from amqtt.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+class NoAuthPlugin(BaseAuthPlugin):
+
+    async def authenticate(self, *, session: Session) -> bool | None:
+        return False
+
+class AuthPlugin(BaseAuthPlugin):
+
+    async def authenticate(self, *, session: Session) -> bool | None:
+        return True
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -333,7 +333,7 @@ async def test_client_no_auth():
         broker = Broker(plugin_namespace='tests.mock_plugins', config=config)
         await broker.start()
 
-
         with pytest.raises(ConnectError):
             await client.connect("mqtt://127.0.0.1:1883/")
 
+        await broker.shutdown()


### PR DESCRIPTION
# Summary

reconnect functionality properly handled an authentication failure. however, when reconnect is False, the client throws a NoDataError. #210 

# What Changed

- if reading for the Connack response fails, catch the NoDataError and raise ConnectError

# Test

additional test added to cover case