### PR TITLE
new vs get_event_loop

### DIFF
--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -180,7 +180,7 @@ class Broker:
             self.config.update(config)
         self._build_listeners_config(self.config)
 
-        self._loop = loop or asyncio.new_event_loop()
+        self._loop = loop or asyncio.get_running_loop()
         self._servers: dict[str, Server] = {}
         self._init_states()
         self._sessions: dict[str, tuple[Session, BrokerProtocolHandler]] = {}

--- a/amqtt/plugins/manager.py
+++ b/amqtt/plugins/manager.py
@@ -8,9 +8,8 @@ from importlib.metadata import EntryPoint, EntryPoints, entry_points
 import logging
 from typing import TYPE_CHECKING, Any, Generic, NamedTuple, Optional, TypeVar
 
-from amqtt.session import Session
-
 from amqtt.errors import PluginImportError, PluginInitError
+from amqtt.session import Session
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/amqtt/scripts/broker_script.py
+++ b/amqtt/scripts/broker_script.py
@@ -54,11 +54,10 @@ def broker_main(
         typer.echo(f"❌ Config file error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
-
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
-        broker = Broker(config)
+        broker = Broker(config, loop=loop)
     except (BrokerError, ParserError, PluginError) as exc:
         typer.echo(f"❌ Broker failed to start: {exc}", err=True)
         raise typer.Exit(code=1) from exc

--- a/tests/plugins/test_sys.py
+++ b/tests/plugins/test_sys.py
@@ -13,10 +13,6 @@ logger = logging.getLogger(__name__)
 
 # test broker sys
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="see https://github.com/Yakifo/aio-amqtt/issues/215",
-    strict=False,
-)
 async def test_broker_sys_plugin() -> None:
 
     class MockEntryPoints:

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -630,10 +630,6 @@ async def test_client_subscribe_publish_dollar_topic_2(broker):
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="see https://github.com/Yakifo/aio-amqtt/issues/16",
-    strict=False,
-)
 async def test_client_publish_retain_subscribe(broker):
     sub_client = MQTTClient()
     await sub_client.connect("mqtt://127.0.0.1", cleansession=False)


### PR DESCRIPTION
# Summary

If a loop wasn't provided, the broker was creating a new loop. This caused the broker to run in one event loop and its tasks to run in a different, causing inconsistencies.

# What changed

While the broker instantiation isn't a coroutine, `broker.start` is a coroutine so the loop that is defined within the __init__ method needs to match the loop that is being used to create tasks. If it isn't, python throws errors that tasks are being created in separate event loops.

# Tests

- fixes test_sys 