### PR TITLE
All events should be a `StrEnum`

### DIFF
--- a/amqtt/__init__.py
+++ b/amqtt/__init__.py
@@ -1,26 +1,3 @@
 """INIT."""
 
 __version__ = "0.11.0"
-
-from enum import StrEnum
-
-
-class Events(StrEnum):
-    """Class for all events."""
-
-class ClientEvents(Events):
-    """Events issued by the client."""
-
-
-class BrokerEvents(Events):
-    """Events issued by the broker."""
-
-    PRE_START = "broker_pre_start"
-    POST_START = "broker_post_start"
-    PRE_SHUTDOWN = "broker_pre_shutdown"
-    POST_SHUTDOWN = "broker_post_shutdown"
-    CLIENT_CONNECTED = "broker_client_connected"
-    CLIENT_DISCONNECTED = "broker_client_disconnected"
-    CLIENT_SUBSCRIBED = "broker_client_subscribed"
-    CLIENT_UNSUBSCRIBED = "broker_client_unsubscribed"
-    MESSAGE_RECEIVED = "broker_message_received"

--- a/amqtt/__init__.py
+++ b/amqtt/__init__.py
@@ -1,3 +1,26 @@
 """INIT."""
 
-__version__ = "0.11.0-rc"
+__version__ = "0.11.0"
+
+from enum import StrEnum
+
+
+class Events(StrEnum):
+    """Class for all events."""
+
+class ClientEvents(Events):
+    """Events issued by the client."""
+
+
+class BrokerEvents(Events):
+    """Events issued by the broker."""
+
+    PRE_START = "broker_pre_start"
+    POST_START = "broker_post_start"
+    PRE_SHUTDOWN = "broker_pre_shutdown"
+    POST_SHUTDOWN = "broker_post_shutdown"
+    CLIENT_CONNECTED = "broker_client_connected"
+    CLIENT_DISCONNECTED = "broker_client_disconnected"
+    CLIENT_SUBSCRIBED = "broker_client_subscribed"
+    CLIENT_UNSUBSCRIBED = "broker_client_unsubscribed"
+    MESSAGE_RECEIVED = "broker_message_received"

--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -28,7 +28,7 @@ from amqtt.mqtt.protocol.broker_handler import BrokerProtocolHandler
 from amqtt.session import ApplicationMessage, OutgoingApplicationMessage, Session
 from amqtt.utils import format_client_message, gen_client_id, read_yaml_config
 
-from . import BrokerEvents
+from .events import BrokerEvents
 from .mqtt.disconnect import DisconnectPacket
 from .plugins.manager import BaseContext, PluginManager
 

--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -28,6 +28,7 @@ from amqtt.mqtt.protocol.broker_handler import BrokerProtocolHandler
 from amqtt.session import ApplicationMessage, OutgoingApplicationMessage, Session
 from amqtt.utils import format_client_message, gen_client_id, read_yaml_config
 
+from . import BrokerEvents
 from .mqtt.disconnect import DisconnectPacket
 from .plugins.manager import BaseContext, PluginManager
 
@@ -41,20 +42,6 @@ _defaults = read_yaml_config(Path(__file__).parent / "scripts/default_broker.yam
 # Default port numbers
 DEFAULT_PORTS = {"tcp": 1883, "ws": 8883}
 AMQTT_MAGIC_VALUE_RET_SUBSCRIBED = 0x80
-
-
-class EventBroker(Enum):
-    """Events issued by the broker."""
-
-    PRE_START = "broker_pre_start"
-    POST_START = "broker_post_start"
-    PRE_SHUTDOWN = "broker_pre_shutdown"
-    POST_SHUTDOWN = "broker_post_shutdown"
-    CLIENT_CONNECTED = "broker_client_connected"
-    CLIENT_DISCONNECTED = "broker_client_disconnected"
-    CLIENT_SUBSCRIBED = "broker_client_subscribed"
-    CLIENT_UNSUBSCRIBED = "broker_client_unsubscribed"
-    MESSAGE_RECEIVED = "broker_message_received"
 
 
 class Action(Enum):
@@ -252,11 +239,11 @@ class Broker:
             msg = f"Broker instance can't be started: {exc}"
             raise BrokerError(msg) from exc
 
-        await self.plugins_manager.fire_event(EventBroker.PRE_START.value)
+        await self.plugins_manager.fire_event(BrokerEvents.PRE_START)
         try:
             await self._start_listeners()
             self.transitions.starting_success()
-            await self.plugins_manager.fire_event(EventBroker.POST_START.value)
+            await self.plugins_manager.fire_event(BrokerEvents.POST_START)
             self._broadcast_task = asyncio.ensure_future(self._broadcast_loop())
             self.logger.debug("Broker started")
         except Exception as e:
@@ -337,7 +324,7 @@ class Broker:
         """Stop broker instance."""
         self.logger.info("Shutting down broker...")
         # Fire broker_shutdown event to plugins
-        await self.plugins_manager.fire_event(EventBroker.PRE_SHUTDOWN.value)
+        await self.plugins_manager.fire_event(BrokerEvents.PRE_SHUTDOWN)
 
         # Cleanup all sessions
         for client_id in list(self._sessions.keys()):
@@ -361,7 +348,7 @@ class Broker:
                 self._broadcast_queue.get_nowait()
 
         self.logger.info("Broker closed")
-        await self.plugins_manager.fire_event(EventBroker.POST_SHUTDOWN.value)
+        await self.plugins_manager.fire_event(BrokerEvents.POST_SHUTDOWN)
         self.transitions.stopping_success()
 
     async def _cleanup_session(self, client_id: str) -> None:
@@ -504,7 +491,7 @@ class Broker:
         self._sessions[client_session.client_id] = (client_session, handler)
 
         await handler.mqtt_connack_authorize(authenticated)
-        await self.plugins_manager.fire_event(EventBroker.CLIENT_CONNECTED.value, client_id=client_session.client_id)
+        await self.plugins_manager.fire_event(BrokerEvents.CLIENT_CONNECTED, client_id=client_session.client_id)
 
         self.logger.debug(f"{client_session.client_id} Start messages handling")
         await handler.start()
@@ -607,7 +594,7 @@ class Broker:
         self.logger.debug(f"{client_session.client_id} Disconnecting session")
         await self._stop_handler(handler)
         client_session.transitions.disconnect()
-        await self.plugins_manager.fire_event(EventBroker.CLIENT_DISCONNECTED.value, client_id=client_session.client_id)
+        await self.plugins_manager.fire_event(BrokerEvents.CLIENT_DISCONNECTED, client_id=client_session.client_id)
 
 
     async def _handle_subscription(
@@ -624,7 +611,7 @@ class Broker:
         for index, subscription in enumerate(subscriptions.topics):
             if return_codes[index] != AMQTT_MAGIC_VALUE_RET_SUBSCRIBED:
                 await self.plugins_manager.fire_event(
-                    EventBroker.CLIENT_SUBSCRIBED.value,
+                    BrokerEvents.CLIENT_SUBSCRIBED,
                     client_id=client_session.client_id,
                     topic=subscription[0],
                     qos=subscription[1],
@@ -643,7 +630,7 @@ class Broker:
         for topic in unsubscription.topics:
             self._del_subscription(topic, client_session)
             await self.plugins_manager.fire_event(
-                EventBroker.CLIENT_UNSUBSCRIBED.value,
+                BrokerEvents.CLIENT_UNSUBSCRIBED,
                 client_id=client_session.client_id,
                 topic=topic,
             )
@@ -678,7 +665,7 @@ class Broker:
             self.logger.info(f"{client_session.client_id} forbidden TOPIC {app_message.topic} sent in PUBLISH message.")
         else:
             await self.plugins_manager.fire_event(
-                EventBroker.MESSAGE_RECEIVED.value,
+                BrokerEvents.MESSAGE_RECEIVED,
                 client_id=client_session.client_id,
                 message=app_message,
             )

--- a/amqtt/events.py
+++ b/amqtt/events.py
@@ -1,4 +1,10 @@
-from enum import StrEnum
+try:
+    from enum import StrEnum
+except ImportError:
+    # support for python 3.10
+    from enum import Enum
+    class StrEnum(str, Enum):  #type: ignore[no-redef]
+        pass
 
 
 class Events(StrEnum):

--- a/amqtt/events.py
+++ b/amqtt/events.py
@@ -1,0 +1,28 @@
+from enum import StrEnum
+
+
+class Events(StrEnum):
+    """Class for all events."""
+
+
+class ClientEvents(Events):
+    """Events issued by the client."""
+
+
+class MQTTEvents(Events):
+    PACKET_SENT = "mqtt_packet_sent"
+    PACKET_RECEIVED = "mqtt_packet_received"
+
+
+class BrokerEvents(Events):
+    """Events issued by the broker."""
+
+    PRE_START = "broker_pre_start"
+    POST_START = "broker_post_start"
+    PRE_SHUTDOWN = "broker_pre_shutdown"
+    POST_SHUTDOWN = "broker_post_shutdown"
+    CLIENT_CONNECTED = "broker_client_connected"
+    CLIENT_DISCONNECTED = "broker_client_disconnected"
+    CLIENT_SUBSCRIBED = "broker_client_subscribed"
+    CLIENT_UNSUBSCRIBED = "broker_client_unsubscribed"
+    MESSAGE_RECEIVED = "broker_message_received"

--- a/amqtt/mqtt/protocol/client_handler.py
+++ b/amqtt/mqtt/protocol/client_handler.py
@@ -2,12 +2,13 @@ import asyncio
 from typing import TYPE_CHECKING, Any
 
 from amqtt.errors import AMQTTError, NoDataError
+from amqtt.events import MQTTEvents
 from amqtt.mqtt.connack import ConnackPacket
 from amqtt.mqtt.connect import ConnectPacket, ConnectPayload, ConnectVariableHeader
 from amqtt.mqtt.disconnect import DisconnectPacket
 from amqtt.mqtt.pingreq import PingReqPacket
 from amqtt.mqtt.pingresp import PingRespPacket
-from amqtt.mqtt.protocol.handler import EVENT_MQTT_PACKET_RECEIVED, ProtocolHandler
+from amqtt.mqtt.protocol.handler import ProtocolHandler
 from amqtt.mqtt.suback import SubackPacket
 from amqtt.mqtt.subscribe import SubscribePacket
 from amqtt.mqtt.unsuback import UnsubackPacket
@@ -93,7 +94,7 @@ class ClientProtocolHandler(ProtocolHandler["ClientContext"]):
             connack = await ConnackPacket.from_stream(self.reader)
         except NoDataError as e:
             raise ConnectionError from e
-        await self.plugins_manager.fire_event(EVENT_MQTT_PACKET_RECEIVED, packet=connack, session=self.session)
+        await self.plugins_manager.fire_event(MQTTEvents.PACKET_RECEIVED, packet=connack, session=self.session)
         return connack.return_code
 
     def handle_write_timeout(self) -> None:

--- a/amqtt/mqtt/protocol/handler.py
+++ b/amqtt/mqtt/protocol/handler.py
@@ -21,6 +21,7 @@ from typing import Generic, TypeVar, cast
 
 from amqtt.adapters import ReaderAdapter, WriterAdapter
 from amqtt.errors import AMQTTError, MQTTError, NoDataError, ProtocolHandlerError
+from amqtt.events import MQTTEvents
 from amqtt.mqtt import packet_class
 from amqtt.mqtt.connack import ConnackPacket
 from amqtt.mqtt.connect import ConnectPacket
@@ -58,9 +59,6 @@ from amqtt.mqtt.unsuback import UnsubackPacket
 from amqtt.mqtt.unsubscribe import UnsubscribePacket
 from amqtt.plugins.manager import BaseContext, PluginManager
 from amqtt.session import INCOMING, OUTGOING, ApplicationMessage, IncomingApplicationMessage, OutgoingApplicationMessage, Session
-
-EVENT_MQTT_PACKET_SENT = "mqtt_packet_sent"
-EVENT_MQTT_PACKET_RECEIVED = "mqtt_packet_received"
 
 C = TypeVar("C", bound=BaseContext)
 
@@ -473,7 +471,7 @@ class ProtocolHandler(Generic[C]):
 
                 cls = packet_class(fixed_header)
                 packet = await cls.from_stream(self.reader, fixed_header=fixed_header)
-                await self.plugins_manager.fire_event(EVENT_MQTT_PACKET_RECEIVED, packet=packet, session=self.session)
+                await self.plugins_manager.fire_event(MQTTEvents.PACKET_RECEIVED, packet=packet, session=self.session)
                 if packet.fixed_header is None or packet.fixed_header.packet_type not in (
                     CONNACK,
                     SUBSCRIBE,
@@ -570,7 +568,7 @@ class ProtocolHandler(Generic[C]):
                 self._keepalive_task.cancel()
                 if self.keepalive_timeout is not None:
                     self._keepalive_task = self._loop.call_later(self.keepalive_timeout, self.handle_write_timeout)
-            await self.plugins_manager.fire_event(EVENT_MQTT_PACKET_SENT, packet=packet, session=self.session)
+            await self.plugins_manager.fire_event(MQTTEvents.PACKET_SENT, packet=packet, session=self.session)
         except (ConnectionResetError, BrokenPipeError):
             await self.handle_connection_closed()
         except asyncio.CancelledError as e:

--- a/amqtt/plugins/manager.py
+++ b/amqtt/plugins/manager.py
@@ -8,9 +8,9 @@ from importlib.metadata import EntryPoint, EntryPoints, entry_points
 import logging
 from typing import TYPE_CHECKING, Any, Generic, NamedTuple, Optional, TypeVar
 
-from amqtt.session import Session
-
+from amqtt import Events
 from amqtt.errors import PluginImportError, PluginInitError
+from amqtt.session import Session
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -153,7 +153,7 @@ class PluginManager(Generic[C]):
     def _schedule_coro(self, coro: Awaitable[str | bool | None]) -> asyncio.Future[str | bool | None]:
         return asyncio.ensure_future(coro)
 
-    async def fire_event(self, event_name: str, *args: Any, wait: bool = False, **kwargs: Any) -> None:
+    async def fire_event(self, event_name: Events, *args: Any, wait: bool = False, **kwargs: Any) -> None:
         """Fire an event to plugins.
 
         PluginManager schedules async calls for each plugin on method called "on_" + event_name.

--- a/amqtt/plugins/manager.py
+++ b/amqtt/plugins/manager.py
@@ -8,8 +8,8 @@ from importlib.metadata import EntryPoint, EntryPoints, entry_points
 import logging
 from typing import TYPE_CHECKING, Any, Generic, NamedTuple, Optional, TypeVar
 
-from amqtt import Events
 from amqtt.errors import PluginImportError, PluginInitError
+from amqtt.events import Events
 from amqtt.session import Session
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, call, patch
 import psutil
 import pytest
 
-from amqtt import BrokerEvents
+from amqtt.events import BrokerEvents
 from amqtt.adapters import StreamReaderAdapter, StreamWriterAdapter
 from amqtt.broker import Broker
 from amqtt.client import MQTTClient

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -6,8 +6,9 @@ from unittest.mock import MagicMock, call, patch
 import psutil
 import pytest
 
+from amqtt import BrokerEvents
 from amqtt.adapters import StreamReaderAdapter, StreamWriterAdapter
-from amqtt.broker import EventBroker, Broker
+from amqtt.broker import Broker
 from amqtt.client import MQTTClient
 from amqtt.errors import ConnectError
 from amqtt.mqtt.connack import ConnackPacket
@@ -56,8 +57,8 @@ def test_split_bindaddr_port(input_str, output_addr, output_port):
 async def test_start_stop(broker, mock_plugin_manager):
     mock_plugin_manager.assert_has_calls(
         [
-            call().fire_event(EventBroker.PRE_START.value),
-            call().fire_event(EventBroker.POST_START.value),
+            call().fire_event(BrokerEvents.PRE_START),
+            call().fire_event(BrokerEvents.POST_START),
         ],
         any_order=True,
     )
@@ -65,8 +66,8 @@ async def test_start_stop(broker, mock_plugin_manager):
     await broker.shutdown()
     mock_plugin_manager.assert_has_calls(
         [
-            call().fire_event(EventBroker.PRE_SHUTDOWN.value),
-            call().fire_event(EventBroker.POST_SHUTDOWN.value),
+            call().fire_event(BrokerEvents.PRE_SHUTDOWN),
+            call().fire_event(BrokerEvents.POST_SHUTDOWN),
         ],
         any_order=True,
     )
@@ -87,11 +88,11 @@ async def test_client_connect(broker, mock_plugin_manager):
     mock_plugin_manager.assert_has_calls(
         [
             call().fire_event(
-                EventBroker.CLIENT_CONNECTED.value,
+                BrokerEvents.CLIENT_CONNECTED,
                 client_id=client.session.client_id,
             ),
             call().fire_event(
-                EventBroker.CLIENT_DISCONNECTED.value,
+                BrokerEvents.CLIENT_DISCONNECTED,
                 client_id=client.session.client_id,
             ),
         ],
@@ -224,7 +225,7 @@ async def test_client_subscribe(broker, mock_plugin_manager):
     mock_plugin_manager.assert_has_calls(
         [
             call().fire_event(
-                EventBroker.CLIENT_SUBSCRIBED.value,
+                BrokerEvents.CLIENT_SUBSCRIBED,
                 client_id=client.session.client_id,
                 topic="/topic",
                 qos=QOS_0,
@@ -261,7 +262,7 @@ async def test_client_subscribe_twice(broker, mock_plugin_manager):
     mock_plugin_manager.assert_has_calls(
         [
             call().fire_event(
-                EventBroker.CLIENT_SUBSCRIBED.value,
+                BrokerEvents.CLIENT_SUBSCRIBED,
                 client_id=client.session.client_id,
                 topic="/topic",
                 qos=QOS_0,
@@ -295,13 +296,13 @@ async def test_client_unsubscribe(broker, mock_plugin_manager):
     mock_plugin_manager.assert_has_calls(
         [
             call().fire_event(
-                EventBroker.CLIENT_SUBSCRIBED.value,
+                BrokerEvents.CLIENT_SUBSCRIBED,
                 client_id=client.session.client_id,
                 topic="/topic",
                 qos=QOS_0,
             ),
             call().fire_event(
-                EventBroker.CLIENT_UNSUBSCRIBED.value,
+                BrokerEvents.CLIENT_UNSUBSCRIBED,
                 client_id=client.session.client_id,
                 topic="/topic",
             ),
@@ -326,7 +327,7 @@ async def test_client_publish(broker, mock_plugin_manager):
     mock_plugin_manager.assert_has_calls(
         [
             call().fire_event(
-                EventBroker.MESSAGE_RECEIVED.value,
+                BrokerEvents.MESSAGE_RECEIVED,
                 client_id=pub_client.session.client_id,
                 message=ret_message,
             ),
@@ -498,7 +499,7 @@ async def test_client_publish_big(broker, mock_plugin_manager):
     mock_plugin_manager.assert_has_calls(
         [
             call().fire_event(
-                EventBroker.MESSAGE_RECEIVED.value,
+                BrokerEvents.MESSAGE_RECEIVED,
                 client_id=pub_client.session.client_id,
                 message=ret_message,
             ),

--- a/tests/test_paho.py
+++ b/tests/test_paho.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 from paho.mqtt import client as mqtt_client
 
-from amqtt.broker import EventBroker
+from amqtt.broker import BrokerEvents
 from amqtt.client import MQTTClient
 from amqtt.mqtt.constants import QOS_1, QOS_2
 
@@ -53,11 +53,11 @@ async def test_paho_connect(broker, mock_plugin_manager):
     broker.plugins_manager.assert_has_calls(
         [
             call.fire_event(
-                EventBroker.CLIENT_CONNECTED.value,
+                BrokerEvents.CLIENT_CONNECTED,
                 client_id=client_id,
             ),
             call.fire_event(
-                EventBroker.CLIENT_DISCONNECTED.value,
+                BrokerEvents.CLIENT_DISCONNECTED,
                 client_id=client_id,
             ),
         ],

--- a/tests/test_paho.py
+++ b/tests/test_paho.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 from paho.mqtt import client as mqtt_client
 
-from amqtt.broker import BrokerEvents
+from amqtt.events import BrokerEvents
 from amqtt.client import MQTTClient
 from amqtt.mqtt.constants import QOS_1, QOS_2
 


### PR DESCRIPTION
# What Changed

- use `StrEnum` instead of `Enum` to eliminate the need for `.value`
- `Events` class to type-hint `fire_event`
- Inherit `BrokerEvents`, `MQTTEvents` and `ClientEvents` from `Events`

# Tests

- no change in behavior