### PR TITLE
fixes #35 : optimize event callbacks

### DIFF
--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -3,6 +3,7 @@ import logging
 import unittest
 
 from amqtt.broker import Action
+from amqtt.events import BrokerEvents
 from amqtt.plugins.authentication import BaseAuthPlugin
 from amqtt.plugins.manager import BaseContext, PluginManager
 from amqtt.plugins.topic_checking import BaseTopicPlugin
@@ -25,7 +26,7 @@ class EventTestPlugin(BaseAuthPlugin, BaseTopicPlugin):
         self.test_topic_flag = False
         self.test_event_flag = False
 
-    async def on_test(self) -> None:
+    async def on_broker_message_received(self) -> None:
         self.test_event_flag = True
 
     async def authenticate(self, *, session: Session) -> bool | None:
@@ -52,7 +53,7 @@ class TestPluginManager(unittest.TestCase):
 
     def test_fire_event(self) -> None:
         async def fire_event() -> None:
-            await manager.fire_event("test")
+            await manager.fire_event(BrokerEvents.MESSAGE_RECEIVED)
             await asyncio.sleep(1)
             await manager.close()
 
@@ -64,7 +65,7 @@ class TestPluginManager(unittest.TestCase):
 
     def test_fire_event_wait(self) -> None:
         async def fire_event() -> None:
-            await manager.fire_event("test", wait=True)
+            await manager.fire_event(BrokerEvents.MESSAGE_RECEIVED, wait=True)
             await manager.close()
 
         manager = PluginManager("amqtt.test.plugins", context=None)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,20 +15,20 @@ logging.basicConfig(level=logging.ERROR, format=formatter)
 log = logging.getLogger(__name__)
 
 
-# @pytest.mark.asyncio
-# async def test_connect_tcp():
-#     client = MQTTClient()
-#     await client.connect("mqtt://test.mosquitto.org:1883/")
-#     assert client.session is not None
-#     await client.disconnect()
+@pytest.mark.asyncio
+async def test_connect_tcp():
+    client = MQTTClient()
+    await client.connect("mqtt://broker.hivemq.com:1883/")
+    assert client.session is not None
+    await client.disconnect()
 
 
-# @pytest.mark.asyncio
-# async def test_connect_tcp_secure(ca_file_fixture):
-#     client = MQTTClient(config={"check_hostname": False})
-#     await client.connect("mqtts://test.mosquitto.org:8883/", cafile=ca_file_fixture)
-#     assert client.session is not None
-#     await client.disconnect()
+@pytest.mark.asyncio
+async def test_connect_tcp_secure(ca_file_fixture):
+    client = MQTTClient(config={"check_hostname": False})
+    await client.connect("mqtts://broker.hivemq.com:8883/")
+    assert client.session is not None
+    await client.disconnect()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Summary

Every time an event is triggered, the plugin manager checks every plugin to see if it implements a callback for that event. While checking for the callback is `O(1)`, it scales to `O(m)` where `m` is the number of plugins. And while certain callbacks happen infrequently (start/shutdown of broker), others happen more frequently and scale by the number of clients and others get called every time a packet is sent or received.

# What Changed

- during plugin load, check each plugin instance to see if one or more of the event callbacks are defined. store a list of these as a dictionary (hash) based on the event
- when event is triggered (`fire_event`) check the hash and execute those callbacks

# Tests

- previously added a test which covers validation that all events callbacks get triggered on a plugin