### PR TITLE
client connection timeout

### DIFF
--- a/amqtt/client.py
+++ b/amqtt/client.py
@@ -456,7 +456,7 @@ class MQTTClient:
         # if not self._handler:
         self._handler = ClientProtocolHandler(self.plugins_manager)
 
-        connection_timeout = self.config.get('connection_timeout', None)
+        connection_timeout = self.config.get("connection_timeout", None)
 
         if secure:
             sc = ssl.create_default_context(
@@ -480,10 +480,10 @@ class MQTTClient:
             if scheme in ("mqtt", "mqtts"):
                 conn_reader, conn_writer = await asyncio.wait_for(
                     asyncio.open_connection(
-                    self.session.remote_address,
-                    self.session.remote_port,
-                    **kwargs,
-                ), timeout=connection_timeout)
+                        self.session.remote_address,
+                        self.session.remote_port,
+                        **kwargs,
+                    ), timeout=connection_timeout)
 
                 reader = StreamReaderAdapter(conn_reader)
                 writer = StreamWriterAdapter(conn_writer)

--- a/amqtt/client.py
+++ b/amqtt/client.py
@@ -456,6 +456,8 @@ class MQTTClient:
         # if not self._handler:
         self._handler = ClientProtocolHandler(self.plugins_manager)
 
+        connection_timeout = self.config.get('connection_timeout', None)
+
         if secure:
             sc = ssl.create_default_context(
                 ssl.Purpose.SERVER_AUTH,
@@ -476,21 +478,24 @@ class MQTTClient:
 
             # Open connection
             if scheme in ("mqtt", "mqtts"):
-                conn_reader, conn_writer = await asyncio.open_connection(
+                conn_reader, conn_writer = await asyncio.wait_for(
+                    asyncio.open_connection(
                     self.session.remote_address,
                     self.session.remote_port,
                     **kwargs,
-                )
+                ), timeout=connection_timeout)
 
                 reader = StreamReaderAdapter(conn_reader)
                 writer = StreamWriterAdapter(conn_writer)
             elif scheme in ("ws", "wss") and self.session.broker_uri:
-                websocket: ClientConnection = await websockets.connect(
-                    self.session.broker_uri,
-                    subprotocols=[websockets.Subprotocol("mqtt")],
-                    additional_headers=self.additional_headers,
-                    **kwargs,
-                )
+                websocket: ClientConnection = await asyncio.wait_for(
+                    websockets.connect(
+                        self.session.broker_uri,
+                        subprotocols=[websockets.Subprotocol("mqtt")],
+                        additional_headers=self.additional_headers,
+                        **kwargs,
+                    ), timeout=connection_timeout)
+
                 reader = WebSocketsReader(websocket)
                 writer = WebSocketsWriter(websocket)
             elif not self.session.broker_uri:

--- a/docs/references/client_config.md
+++ b/docs/references/client_config.md
@@ -25,6 +25,11 @@ Default retain value to messages published. Defaults to `false`.
 
 Enable or disable auto-reconnect if connection with the broker is interrupted. Defaults to `false`.
 
+
+### `connect_timeout` *(int)*
+
+If specified, the number of seconds before a connection times out 
+
 ### `reconnect_retries` *(int)*
  
 Maximum reconnection retries. Defaults to `2`. Negative value will cause client to reconnect infinitely.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -446,6 +446,15 @@ async def test_connect_incorrect_scheme():
         await client.connect('"mq://someplace')
 
 
+@pytest.mark.asyncio
+@pytest.mark.timeout(3)
+async def test_connect_timeout():
+    config = {"auto_reconnect": False, "connection_timeout": 2}
+    client = MQTTClient(config=config)
+    with pytest.raises(ClientError):
+        await client.connect("mqtt://localhost:8888")
+
+
 async def test_client_no_auth():
 
     class MockEntryPoints:


### PR DESCRIPTION
### Changes included in this PR

If connection takes longer than certain amount of seconds, cause the connection to timeout.

### Current behavior

Waits an indeterminate amount of time based on behavior of `asyncio.open_connection` or `websocket.connect`.

### New behavior

If not specified in the configuration, the behavior will be identical to current. When added to the config, the client will raise a `ConnectError` if the client can't connect to the broker.

### Impact

None

### Checklist

1. [X] Does your submission pass the existing tests?
2. [X] Are there new tests that cover these additions/changes?
3. [X] Have you linted your code locally before submission?
