### PR TITLE
dockerfile build update to support psutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 # -- build stage, install dependencies only using `uv`
 FROM python:3.13-alpine AS build
-
+RUN apk add gcc python3-dev musl-dev linux-headers
 RUN pip install uv
 
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Image name and tag
 IMAGE_NAME := amqtt
 IMAGE_TAG := latest
-VERSION_TAG := 0.11.0
+VERSION_TAG := 0.11.1
 REGISTRY := amqtt/$(IMAGE_NAME)
 
 # Platforms to build for


### PR DESCRIPTION
### Changes included in this PR

In order to use `psutils` python module within an alpine docker container, need to install gcc and other support libraries in the build container.

1. [X] Does your submission pass the existing tests?
2. [X] Are there new tests that cover these additions/changes?
3. [X] Have you linted your code locally before submission?
