### PR TITLE
pass client session info to event callbacks

### DIFF
--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -491,7 +491,9 @@ class Broker:
         self._sessions[client_session.client_id] = (client_session, handler)
 
         await handler.mqtt_connack_authorize(authenticated)
-        await self.plugins_manager.fire_event(BrokerEvents.CLIENT_CONNECTED, client_id=client_session.client_id)
+        await self.plugins_manager.fire_event(BrokerEvents.CLIENT_CONNECTED,
+                                              client_id=client_session.client_id,
+                                              client_session=client_session)
 
         self.logger.debug(f"{client_session.client_id} Start messages handling")
         await handler.start()
@@ -594,7 +596,9 @@ class Broker:
         self.logger.debug(f"{client_session.client_id} Disconnecting session")
         await self._stop_handler(handler)
         client_session.transitions.disconnect()
-        await self.plugins_manager.fire_event(BrokerEvents.CLIENT_DISCONNECTED, client_id=client_session.client_id)
+        await self.plugins_manager.fire_event(BrokerEvents.CLIENT_DISCONNECTED,
+                                              client_id=client_session.client_id,
+                                              client_session=client_session)
 
 
     async def _handle_subscription(

--- a/amqtt/plugins/sys/broker.py
+++ b/amqtt/plugins/sys/broker.py
@@ -225,7 +225,7 @@ class BrokerSysPlugin(BasePlugin[BrokerContext]):
             if packet.fixed_header.packet_type == PUBLISH:
                 self._stats[STAT_PUBLISH_SENT] += 1
 
-    async def on_broker_client_connected(self, client_id: str) -> None:
+    async def on_broker_client_connected(self, client_id: str, client_session: Session) -> None:
         """Handle broker client connection."""
         self._stats[STAT_CLIENTS_CONNECTED] += 1
         self._stats[STAT_CLIENTS_MAXIMUM] = max(
@@ -233,7 +233,7 @@ class BrokerSysPlugin(BasePlugin[BrokerContext]):
             self._stats[STAT_CLIENTS_CONNECTED],
         )
 
-    async def on_broker_client_disconnected(self, client_id: str) -> None:
+    async def on_broker_client_disconnected(self, client_id: str, client_session: Session) -> None:
         """Handle broker client disconnection."""
         self._stats[STAT_CLIENTS_CONNECTED] -= 1
         self._stats[STAT_CLIENTS_DISCONNECTED] += 1

--- a/docs/custom_plugins.md
+++ b/docs/custom_plugins.md
@@ -36,8 +36,8 @@ implements one or more of these methods:
 - `async def on_broker_pre_shutdown(self) -> None`
 - `async def on_broker_post_shutdown(self) -> None`
 
-- `async def on_broker_client_connected(self, client_id:str, client_session:Session) -> None`
-- `async def on_broker_client_disconnected(self, client_id:str, client_session:Session) -> None`
+- `async def on_broker_client_connected(self, *, client_id:str, client_session:Session) -> None`
+- `async def on_broker_client_disconnected(self, *, client_id:str, client_session:Session) -> None`
 
 - `async def on_broker_client_connected(self, *, client_id:str) -> None`
 - `async def on_broker_client_disconnected(self, *, client_id:str) -> None`

--- a/docs/custom_plugins.md
+++ b/docs/custom_plugins.md
@@ -28,21 +28,24 @@ its own variables to configure its behavior.
 Plugins that are defined in the`project.entry-points` are notified of events if the subclass 
 implements one or more of these methods:
 
-- `async def on_mqtt_packet_sent(self, packet: MQTTPacket[MQTTVariableHeader, MQTTPayload[MQTTVariableHeader], MQTTFixedHeader], session: Session | None = None) -> None`
-- `async def on_mqtt_packet_received(self, packet: MQTTPacket[MQTTVariableHeader, MQTTPayload[MQTTVariableHeader], MQTTFixedHeader], session: Session | None = None) -> None`
+- `async def on_mqtt_packet_sent(self, *, packet: MQTTPacket[MQTTVariableHeader, MQTTPayload[MQTTVariableHeader], MQTTFixedHeader], session: Session | None = None) -> None`
+- `async def on_mqtt_packet_received(self, *, packet: MQTTPacket[MQTTVariableHeader, MQTTPayload[MQTTVariableHeader], MQTTFixedHeader], session: Session | None = None) -> None`
 
-- `async def on_broker_pre_start() -> None`
-- `async def on_broker_post_start() -> None`
-- `async def on_broker_pre_shutdown() -> None`
-- `async def on_broker_post_shutdown() -> None`
+- `async def on_broker_pre_start(self) -> None`
+- `async def on_broker_post_start(self) -> None`
+- `async def on_broker_pre_shutdown(self) -> None`
+- `async def on_broker_post_shutdown(self) -> None`
 
 - `async def on_broker_client_connected(self, client_id:str, client_session:Session) -> None`
 - `async def on_broker_client_disconnected(self, client_id:str, client_session:Session) -> None`
 
-- `async def on_broker_client_subscribed(self, client_id: str, topic: str, qos: int) -> None`
-- `async def on_broker_client_unsubscribed(self, client_id: str, topic: str) -> None`
+- `async def on_broker_client_connected(self, *, client_id:str) -> None`
+- `async def on_broker_client_disconnected(self, *, client_id:str) -> None`
 
-- `async def on_broker_message_received(self, client_id: str, message: ApplicationMessage) -> None`
+- `async def on_broker_client_subscribed(self, *, client_id: str, topic: str, qos: int) -> None`
+- `async def on_broker_client_unsubscribed(self, *, client_id: str, topic: str) -> None`
+
+- `async def on_broker_message_received(self, *, client_id: str, message: ApplicationMessage) -> None`
 
 
 ## Authentication Plugins

--- a/docs/custom_plugins.md
+++ b/docs/custom_plugins.md
@@ -36,8 +36,8 @@ implements one or more of these methods:
 - `async def on_broker_pre_shutdown() -> None`
 - `async def on_broker_post_shutdown() -> None`
 
-- `async def on_broker_client_connected(self, client_id:str) -> None`
-- `async def on_broker_client_disconnected(self, client_id:str) -> None`
+- `async def on_broker_client_connected(self, client_id:str, client_session:Session) -> None`
+- `async def on_broker_client_disconnected(self, client_id:str, client_session:Session) -> None`
 
 - `async def on_broker_client_subscribed(self, client_id: str, topic: str, qos: int) -> None`
 - `async def on_broker_client_unsubscribed(self, client_id: str, topic: str) -> None`

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -85,19 +85,13 @@ async def test_client_connect(broker, mock_plugin_manager):
 
     await asyncio.sleep(0.01)
 
-    mock_plugin_manager.assert_has_calls(
-        [
-            call().fire_event(
-                BrokerEvents.CLIENT_CONNECTED,
-                client_id=client.session.client_id,
-            ),
-            call().fire_event(
-                BrokerEvents.CLIENT_DISCONNECTED,
-                client_id=client.session.client_id,
-            ),
-        ],
-        any_order=True,
-    )
+    broker.plugins_manager.fire_event.assert_called()
+    assert broker.plugins_manager.fire_event.call_count > 2
+
+    # double indexing is ugly, but call_args_list returns a tuple of tuples
+    events = [c[0][0] for c in broker.plugins_manager.fire_event.call_args_list]
+    assert BrokerEvents.CLIENT_CONNECTED in events
+    assert BrokerEvents.CLIENT_DISCONNECTED in events
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Changes included in this PR

add parameter to provide the client session to the client connected and client disconnected events:


- `async def on_broker_client_connected(self, client_id:str, client_session:Session) -> None`
- `async def on_broker_client_disconnected(self, client_id:str, client_session:Session) -> None`


### Impact

plugins which currently define these two event callbacks will need to add the additional keyword parameter `client_session`

### Checklist

1. [X] Does your submission pass the existing tests?
2. [X] Are there new tests that cover these additions/changes?
3. [X] Have you linted your code locally before submission?
