### PR TITLE
Plugin naming convention

### DIFF
--- a/amqtt/contrib/auth_db/plugin.py
+++ b/amqtt/contrib/auth_db/plugin.py
@@ -20,7 +20,7 @@ def default_hash_scheme() -> list[str]:
     return ["argon2", "bcrypt", "pbkdf2_sha256", "scrypt"]
 
 
-class UserAuthDBPlugin(BaseAuthPlugin, BaseTopicPlugin):
+class UserAuthDBPlugin(BaseAuthPlugin):
 
     def __init__(self, context: BrokerContext) -> None:
         super().__init__(context)

--- a/amqtt/contrib/http.py
+++ b/amqtt/contrib/http.py
@@ -15,7 +15,7 @@ from aiohttp import ClientResponse, ClientSession, FormData
 
 from amqtt.broker import BrokerContext
 from amqtt.contexts import Action
-from amqtt.plugins.base import BaseAuthPlugin, BaseTopicPlugin, BasePlugin
+from amqtt.plugins.base import BaseAuthPlugin, BasePlugin, BaseTopicPlugin
 from amqtt.session import Session
 
 logger = logging.getLogger(__name__)
@@ -72,7 +72,7 @@ class HttpConfig:
     """duration, in seconds, to wait for the HTTP server to respond"""
 
 
-class HttpPlugin(BasePlugin):
+class AuthHttpPlugin(BasePlugin[BrokerContext]):
 
     def __init__(self, context: BrokerContext) -> None:
         super().__init__(context)
@@ -138,7 +138,7 @@ class HttpPlugin(BasePlugin):
         return f"{'https' if self.config.with_tls else 'http'}://{self.config.host}:{self.config.port}{uri}"
 
 
-class HttpAuthPlugin(HttpPlugin, BaseAuthPlugin):
+class UserAuthHttpPlugin(AuthHttpPlugin, BaseAuthPlugin):
 
     async def authenticate(self, *, session: Session) -> bool | None:
         d = {"username": session.username, "password": session.password, "client_id": session.client_id}
@@ -152,7 +152,7 @@ class HttpAuthPlugin(HttpPlugin, BaseAuthPlugin):
         """URI of the auth check."""
 
 
-class HttpTopicPlugin(HttpPlugin, BaseTopicPlugin):
+class TopicAuthHttpPlugin(AuthHttpPlugin, BaseTopicPlugin):
 
     async def topic_filtering(self, *,
                         session: Session | None = None,
@@ -175,5 +175,6 @@ class HttpTopicPlugin(HttpPlugin, BaseTopicPlugin):
     @dataclass
     class Config(HttpConfig):
         """Configuration for the HTTP Topic Plugin."""
+
         topic_uri: str = "/acl"
         """URI of the topic check."""

--- a/docs/plugins/auth_db.md
+++ b/docs/plugins/auth_db.md
@@ -1,7 +1,7 @@
 # Relational Database for Authentication and Authorization
 
-- `amqtt.contrib.auth_db.AuthUserDBPlugin` (authentication) verify a client's ability to connect to broker
-- `amqtt.contrib.auth_db.AuthTopicDBPlugin` (authorization) determine a client's access to topics
+- `amqtt.contrib.auth_db.UserAuthDBPlugin` (authentication) verify a client's ability to connect to broker
+- `amqtt.contrib.auth_db.TopicAuthDBPlugin` (authorization) determine a client's access to topics
 
 Relational database access is supported using SQLAlchemy so MySQL, MariaDB, Postgres and SQLite support is available.
 

--- a/docs/plugins/http.md
+++ b/docs/plugins/http.md
@@ -1,9 +1,16 @@
 # Authentication & Authorization via external HTTP server
 
-`amqtt.contrib.http.HttpAuthPlugin`
-
 If clients accessing the broker are managed by another application, it can implement API endpoints
-that respond with information about client authenticated and topic-level authorization.
+that respond with information about client authentication and/or topic-level authorization.
+
+- `amqtt.contrib.http.UserAuthHttpPlugin` (client authentication)
+- `amqtt.contrib.http.TopicAuthHttpPlugin` (topic authorization)
+
+Configuration of these plugins is identical (except for the uri name) so that they can be used independently, if desired.
+
+## User Auth
+
+See the [Request and Response Modes](#request-response-modes) section below for details on `params_mode` and `response_mode`.
 
 !!! info "browser-based mqtt over websockets"
 
@@ -35,9 +42,18 @@ that respond with information about client authenticated and topic-level authori
             try {
               const clientMqtt = await mqtt.connect(url, options);
 
-See the [Request and Response Modes](#request-response-modes) section below for details on `params_mode` and `response_mode`. 
+::: amqtt.contrib.http.UserAuthHttpPlugin.Config
+    options:
+      show_source: false
+      heading_level: 4
+      extra:
+        class_style: "simple"
 
-::: amqtt.contrib.http.HttpAuthPlugin.Config
+## Topic ACL
+
+See the [Request and Response Modes](#request-response-modes) section below for details on `params_mode` and `response_mode`.
+
+::: amqtt.contrib.http.TopicAuthHttpPlugin.Config
     options:
       show_source: false
       heading_level: 4
@@ -57,10 +73,6 @@ format will depend on `params_mode` configuration attribute (`json` or `form`).:
     - password *(str)*
     - client_id *(str)*
 
-*For superuser validation, the request will contain:*
-
-    - username *(str)*
-
 *For acl check, the request will contain:*
 
     - username *(str)*
@@ -75,8 +87,8 @@ All endpoints should respond with the following, dependent on `response_mode` co
     - status code: 2xx (granted) or 4xx(denied) or 5xx (noop)
 
 !!! note "5xx response"
-    **noop** (no operation): plugin will not participate in the filtering operation and will defer to another
-    topic filtering plugin to determine access. if there is no other topic filtering plugin, access will be denied.
+    **noop** (no operation): plugin will not participate in the operation and will defer to another
+    plugin to determine access. if there is no other auth/filtering plugin, access will be denied.
 
 *In `json` mode:*
 
@@ -87,8 +99,8 @@ All endpoints should respond with the following, dependent on `response_mode` co
                 or { 'error': 'optional error message' } (noop)
 
 !!! note "excluded 'ok' key"
-    **noop** (no operation): plugin will not participate in the filtering operation and will defer to another
-     topic filtering plugin to determine access. if there is no other topic filtering plugin, access will be denied.
+    **noop** (no operation): plugin will not participate in the operation and will defer to another
+    plugin to determine access. if there is no other auth/filtering plugin, access will be denied.
 
 *In `text` mode:*
 

--- a/tests/contrib/test_http.py
+++ b/tests/contrib/test_http.py
@@ -8,7 +8,7 @@ from aiohttp.web import Response
 
 from amqtt.broker import BrokerContext, Broker
 from amqtt.contexts import Action
-from amqtt.contrib.http import HttpAuthPlugin, ParamsMode, ResponseMode, RequestMethod, HttpTopicPlugin
+from amqtt.contrib.http import UserAuthHttpPlugin, TopicAuthHttpPlugin, ParamsMode, ResponseMode, RequestMethod
 from amqtt.session import Session
 
 logger = logging.getLogger(__name__)
@@ -135,7 +135,7 @@ async def test_request_auth_response(empty_broker, http_server, kind, url,
                                      username, matcher, is_allowed):
 
     context = BrokerContext(broker=empty_broker)
-    context.config = HttpAuthPlugin.Config(
+    context.config = UserAuthHttpPlugin.Config(
         host="127.0.0.1",
         port=8080,
         user_uri=url,
@@ -143,7 +143,7 @@ async def test_request_auth_response(empty_broker, http_server, kind, url,
         params_mode=params_mode,
         response_mode=response_mode,
     )
-    http_acl = HttpAuthPlugin(context)
+    http_acl = UserAuthHttpPlugin(context)
     logger.warning(f'kind is {kind}')
 
     session = Session()
@@ -162,7 +162,7 @@ async def test_request_topic_response(empty_broker, http_server, kind, url,
                                      request_method, params_mode, response_mode,
                                      username, matcher, is_allowed):
     context = BrokerContext(broker=empty_broker)
-    context.config = HttpTopicPlugin.Config(
+    context.config = TopicAuthHttpPlugin.Config(
         host="127.0.0.1",
         port=8080,
         topic_uri=url,
@@ -170,7 +170,7 @@ async def test_request_topic_response(empty_broker, http_server, kind, url,
         params_mode=params_mode,
         response_mode=response_mode,
     )
-    http_acl = HttpTopicPlugin(context)
+    http_acl = TopicAuthHttpPlugin(context)
 
     s = Session()
     s.username = username

--- a/tests/contrib/test_http.py
+++ b/tests/contrib/test_http.py
@@ -8,7 +8,7 @@ from aiohttp.web import Response
 
 from amqtt.broker import BrokerContext, Broker
 from amqtt.contexts import Action
-from amqtt.contrib.http import HttpAuthPlugin, ParamsMode, ResponseMode, RequestMethod
+from amqtt.contrib.http import HttpAuthPlugin, ParamsMode, ResponseMode, RequestMethod, HttpTopicPlugin
 from amqtt.session import Session
 
 logger = logging.getLogger(__name__)
@@ -91,46 +91,46 @@ def test_server_up_and_down(http_server):
     pass
 
 
-class TestKind(Enum):
+class TypeOfHttpTest(Enum):
     AUTH = auto()
     ACL = auto()
 
 
-def generate_use_cases():
+def generate_use_cases(kind: TypeOfHttpTest):
     # generate all variations of the plugin's configuration options for both auth and topic
     # e.g. (TestKind.AUTH, '/user/json', RequestMethod.GET, ParamsMode.JSON, ResponseMode.JSON, 'json', 'json', True),
 
     cases: list[tuple[str, str, RequestMethod, ParamsMode, ResponseMode, str, str, bool]] = []
-    for kind in TestKind:
-        root_url = 'user' if kind == TestKind.AUTH else 'acl'
-        for request in RequestMethod:
-            for params in ParamsMode:
-                for response in ResponseMode:
-                    url = f'/{root_url}/json' if params == ParamsMode.JSON else f'/{root_url}/form'
-                    for is_authenticated in [True, False, None]:
-                        if is_authenticated is None:
-                            pwd = 'i_am_null'
-                        elif is_authenticated:
-                            pwd = f'{response.value}'
-                        else:
-                            pwd = f'not{response.value}'
 
-                        if response == ResponseMode.TEXT and is_authenticated is None:
-                            is_authenticated = False
+    root_url = 'user' if kind == TypeOfHttpTest.AUTH else 'acl'
+    for request in RequestMethod:
+        for params in ParamsMode:
+            for response in ResponseMode:
+                url = f'/{root_url}/json' if params == ParamsMode.JSON else f'/{root_url}/form'
+                for is_authenticated in [True, False, None]:
+                    if is_authenticated is None:
+                        pwd = 'i_am_null'
+                    elif is_authenticated:
+                        pwd = f'{response.value}'
+                    else:
+                        pwd = f'not{response.value}'
 
-                        case = (kind, url, request, params, response, response.value, f"{pwd}", is_authenticated)
-                        cases.append(case)
+                    if response == ResponseMode.TEXT and is_authenticated is None:
+                        is_authenticated = False
+
+                    case = (kind, url, request, params, response, response.value, f"{pwd}", is_authenticated)
+                    cases.append(case)
     return cases
 
 def test_generated_use_cases():
-    cases = generate_use_cases()
-    assert len(cases) == 108
+    cases = generate_use_cases(kind=TypeOfHttpTest.AUTH)
+    assert len(cases) == 54
 
 
 @pytest.mark.parametrize("kind,url,request_method,params_mode,response_mode,username,matcher,is_allowed",
-                             generate_use_cases())
+                         generate_use_cases(TypeOfHttpTest.AUTH))
 @pytest.mark.asyncio
-async def test_request_acl_response(empty_broker, http_server, kind, url,
+async def test_request_auth_response(empty_broker, http_server, kind, url,
                                      request_method, params_mode, response_mode,
                                      username, matcher, is_allowed):
 
@@ -139,25 +139,50 @@ async def test_request_acl_response(empty_broker, http_server, kind, url,
         host="127.0.0.1",
         port=8080,
         user_uri=url,
-        topic_uri=url,
         request_method=request_method,
         params_mode=params_mode,
         response_mode=response_mode,
     )
     http_acl = HttpAuthPlugin(context)
     logger.warning(f'kind is {kind}')
-    if kind == TestKind.ACL:
-        s = Session()
-        s.username = username
-        s.client_id = matcher
-        t = 'my/topic'
-        a = Action.PUBLISH
-        assert await http_acl.topic_filtering(session=s, topic=t, action=a) == is_allowed
-    else:
-        session = Session()
-        session.client_id = "my_client_id"
-        session.username = username
-        session.password = matcher
-        assert await http_acl.authenticate(session=session) == is_allowed
+
+    session = Session()
+    session.client_id = "my_client_id"
+    session.username = username
+    session.password = matcher
+    assert await http_acl.authenticate(session=session) == is_allowed
 
     await http_acl.on_broker_pre_shutdown()
+
+
+@pytest.mark.parametrize("kind,url,request_method,params_mode,response_mode,username,matcher,is_allowed",
+                         generate_use_cases(TypeOfHttpTest.ACL))
+@pytest.mark.asyncio
+async def test_request_topic_response(empty_broker, http_server, kind, url,
+                                     request_method, params_mode, response_mode,
+                                     username, matcher, is_allowed):
+    context = BrokerContext(broker=empty_broker)
+    context.config = HttpTopicPlugin.Config(
+        host="127.0.0.1",
+        port=8080,
+        topic_uri=url,
+        request_method=request_method,
+        params_mode=params_mode,
+        response_mode=response_mode,
+    )
+    http_acl = HttpTopicPlugin(context)
+
+    s = Session()
+    s.username = username
+    s.client_id = matcher
+    t = 'my/topic'
+    a = Action.PUBLISH
+    assert await http_acl.topic_filtering(session=s, topic=t, action=a) == is_allowed
+
+    await http_acl.on_broker_pre_shutdown()
+
+
+
+    # if kind == TestKind.ACL:
+
+    # else:


### PR DESCRIPTION
### Changes included in this PR

Renaming http and db plugins to follow a more consistent naming convention: 

- User Authentication (`UserAuth`)
- Topic Authorization  (`TopicAuth`)

Updating tests and documentation to match.

Also, splitting the HTTP plugin into two plugins, one for user authentication the other for topic authorization.

This allows plugins to be mixed-and-matched.

### Checklist

1. [X] Does your submission pass the existing tests?
~2. [ ] Are there new tests that cover these additions/changes?~ NA
3. [X] Have you linted your code locally before submission?
