### PR TITLE
a connection without peer info should be rejected (#300)

### DIFF
--- a/amqtt/adapters.py
+++ b/amqtt/adapters.py
@@ -176,8 +176,10 @@ class StreamWriterAdapter(WriterAdapter):
         if not self.is_closed:
             await self._writer.drain()
 
-    def get_peer_info(self) -> tuple[str, int]:
+    def get_peer_info(self) -> tuple[str, int] | None:
         extra_info = self._writer.get_extra_info("peername")
+        if not extra_info or len(extra_info) < 2:
+            return None
         return extra_info[0], extra_info[1]
 
     def get_ssl_info(self) -> ssl.SSLObject | None:

--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -444,6 +444,8 @@ class Broker:
         remote_info = writer.get_peer_info()
         if remote_info is None:
             self.logger.warning("Remote info could not be retrieved from peer info")
+            await writer.close() # python 3.10 needs explicit close
+            server.release_connection()
             return
 
         remote_address, remote_port = remote_info

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1028,3 +1028,14 @@ async def test_broker_with_absent_auth_plugin_filter():
     await mqtt_client.connect()
 
     await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_client_without_peer_info(broker, mock_plugin_manager):
+    client = MQTTClient(config={'auto_reconnect':False})
+
+    # if the broker's stream writer for this client does not have peer info, the client should fail to connect
+    with patch.object(asyncio.streams.StreamWriter, 'get_extra_info', return_value=None) as mock_extra_info:
+        with pytest.raises(ConnectError):
+            await client.connect("mqtt://127.0.0.1/")
+            await asyncio.sleep(0.01)


### PR DESCRIPTION
### Changes included in this PR

If a connection doesn't have information about the remote address or port, then the connection should fail gracefully

Fixed `get_peer_info` so that it checks for return value of get_extra_info before separating the address and port.

### Checklist

1. [x] Does your submission pass the existing tests?
2. [x] Are there new tests that cover these additions/changes?
3. [x] Have you linted your code locally before submission?
