### PR TITLE
Remove pytest marks from fixtures so tests work with PyTest 9

### DIFF
--- a/tests/contrib/test_db_plugin.py
+++ b/tests/contrib/test_db_plugin.py
@@ -40,7 +40,6 @@ def db_connection(db_file):
 
 
 @pytest.fixture
-@pytest.mark.asyncio
 async def user_manager(password_hasher, db_connection):
     um = UserManager(db_connection)
     await um.db_sync()
@@ -48,7 +47,6 @@ async def user_manager(password_hasher, db_connection):
 
 
 @pytest.fixture
-@pytest.mark.asyncio
 async def topic_manager(password_hasher, db_connection):
     tm = TopicManager(db_connection)
     await tm.db_sync()

--- a/tests/contrib/test_db_scripts.py
+++ b/tests/contrib/test_db_scripts.py
@@ -36,7 +36,6 @@ def db_connection(db_file):
 
 
 @pytest.fixture
-@pytest.mark.asyncio
 async def user_manager(password_hasher, db_connection):
     um = UserManager(db_connection)
     await um.db_sync()
@@ -44,7 +43,6 @@ async def user_manager(password_hasher, db_connection):
 
 
 @pytest.fixture
-@pytest.mark.asyncio
 async def topic_manager(password_hasher, db_connection):
     tm = TopicManager(db_connection)
     await tm.db_sync()
@@ -417,4 +415,3 @@ async def test_topic_mgr_cli():
     stdout, stderr = await proc.communicate()
 
     assert proc.returncode == 0, f"topic_mgr error code: {proc.returncode} - {stdout} - {stderr}"
-

--- a/tests/contrib/test_shadows.py
+++ b/tests/contrib/test_shadows.py
@@ -32,7 +32,6 @@ def db_connection(db_file):
 
 
 @pytest.fixture
-@pytest.mark.asyncio
 async def db_session_maker(db_connection):
     engine = create_async_engine(f"{db_connection}")
     db_session_maker = async_sessionmaker(engine, expire_on_commit=False)
@@ -41,7 +40,6 @@ async def db_session_maker(db_connection):
 
 
 @pytest.fixture
-@pytest.mark.asyncio
 async def shadow_plugin(db_connection):
 
     cfg = ShadowPlugin.Config(connection=db_connection)


### PR DESCRIPTION
Fixes PytestRemovedIn9Warning by dropping marks on fixture functions

Without this change the tests fail with PyTest 9.