### PR TITLE
fix(client): Print whole exceptions only in logging.DEBUG mode

### DIFF
--- a/amqtt/client.py
+++ b/amqtt/client.py
@@ -236,8 +236,7 @@ class MQTTClient:
                 self.logger.warning(f"Reconnection attempt failed: {e!r}")
                 self.logger.debug("", exc_info=True)
                 if 0 <= reconnect_retries < nb_attempt:
-                    self.logger.exception("Maximum connection attempts reached. Reconnection aborted.")
-                    self.logger.debug("", exc_info=True)
+                    self.logger.debug("Maximum connection attempts reached. Reconnection aborted.", exc_info=e)
                     msg = "Too many failed attempts"
                     raise ConnectError(msg) from e
                 delay = min(reconnect_max_interval, 2**nb_attempt)


### PR DESCRIPTION
### Changes included in this PR

Reduce amount of (uncontrollable) text going to stderr

### Current behavior

It prints whole exception on every reconnect try

### New behavior

Whole exception is recorded only in logging.DEBUG level

### Impact

No impact

### Checklist

1. [x] Does your submission pass the existing tests?
2. [ ] Are there new tests that cover these additions/changes?
3. [x] Have you linted your code locally before submission?
