### PR TITLE
Allow insecure TLS client connections

### DIFF
--- a/amqtt/client.py
+++ b/amqtt/client.py
@@ -468,6 +468,11 @@ class MQTTClient:
             if self.config.check_hostname is not None:
                 sc.check_hostname = self.config.check_hostname
                 sc.verify_mode = ssl.CERT_REQUIRED
+            if self.config.verify_cert is False:
+                if self.config.check_hostname:
+                    msg = "verify_cert cannot be disabled when check_hostname is enabled"
+                    raise ClientError(msg)
+                sc.verify_mode = ssl.CERT_NONE
             kwargs["ssl"] = sc
 
         try:

--- a/amqtt/contexts.py
+++ b/amqtt/contexts.py
@@ -347,6 +347,9 @@ class ClientConfig(Dictable):
       more information. `list[str | dict[str,Any]]` is deprecated but available to support legacy use cases."""
     check_hostname: bool | None = True
     """If establishing a secure connection, should the hostname of the certificate be verified."""
+    verify_cert: bool | None = True
+    """If establishing a secure connection, should the certificate be verified. Validation errors, such as untrusted or
+     expired certificate, are ignored. Can only be disabled if `check_hostname` is also disabled."""
     will: WillConfig | None = None
     """Message, topic and flags that should be sent to if the client disconnects. See
     [`WillConfig`](client_config.md#amqtt.contexts.WillConfig) for more information."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -34,12 +34,22 @@ async def test_connect_username_password(broker_fixture):
 
 
 @pytest.mark.asyncio
-async def test_connect_tcp_secure(rsa_keys, broker_fixture):
+async def test_connect_tcp_encrypted_secure(rsa_keys, broker_fixture):
     certfile, _ = rsa_keys
     client = MQTTClient(config={"check_hostname": False, "auto_reconnect": False})
 
     # since we're using a self-signed certificate, need to provide the server's certificate to verify authenticity
     await client.connect("mqtts://localhost:1884/", cafile=certfile)
+    assert client.session is not None
+    await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_connect_tcp_encrypted_insecure(broker_fixture):
+    # self-signed certificate is implicitly used, but explicitly not verified
+    client = MQTTClient(config={"check_hostname": False, "verify_cert": False, "auto_reconnect": False})
+
+    await client.connect("mqtts://localhost:1884/")
     assert client.session is not None
     await client.disconnect()
 


### PR DESCRIPTION
### Changes included in this PR

Feature: Allow insecure TLS client connections. Off by default, optionallay enabled via config option.

### Current behavior

TLS certificates are validated with no option to skip validation e.g. for self-signed certificates.

### New behavior

Option `verify_cert` for clients to skip TLS certificate validation (verify_cert is True by default). Aligns with "--insecure" options for curl, mosquitto and similar.

### Impact

No impact on existing usage.

### Checklist

1. [x] Does your submission pass the existing tests?
2. [x] Are there new tests that cover these additions/changes?
3. [ ] Have you linted your code locally before submission? -> No, the Unix specific pre-commit hooks (.sh) of this project do not work locally on my platform (Windows 11).
