### PR TITLE
sample: custom plugin to bypass mqtt's restriction on publishing to `$` topics

### DIFF
--- a/samples/broker_dollar_topics.py
+++ b/samples/broker_dollar_topics.py
@@ -1,0 +1,85 @@
+import asyncio
+from dataclasses import dataclass
+import logging
+
+from amqtt.broker import Broker
+from amqtt.plugins.base import BasePlugin
+from amqtt.session import Session, ApplicationMessage
+
+"""
+This sample shows how to run a broker without stacktraces on keyboard interrupt
+"""
+
+logger = logging.getLogger(__name__)
+
+
+class ClientDollarBroadcast(BasePlugin):
+
+    async def _broadcast_sys_topic(self, topic_basename: str, data: bytes) -> None:
+        """Broadcast a system topic."""
+    async def on_broker_message_received(self, *, client_id: str, message: ApplicationMessage) -> None:
+        """typically, MQTT-4.7.2-1 blocks clients from sending `$` messages, example how to bypass"""
+        if message.topic.startswith("$"):
+            await self.context.broadcast_message(message.topic, message.data, message.qos)
+
+            # spec doesn't define if we're required to retain `$` topic messages, so this is optional
+            if message.publish_packet and message.publish_packet.retain_flag:
+                await self.context.retain_message(message.topic, message.data, message.qos)
+
+
+config = {
+    "listeners": {
+        "default": {
+            "type": "tcp",
+            "bind": "0.0.0.0:1883",
+        },
+        "ws-mqtt": {
+            "bind": "127.0.0.1:8080",
+            "type": "ws",
+            "max_connections": 10,
+        },
+    },
+    "plugins": {
+        "amqtt.plugins.authentication.AnonymousAuthPlugin": { "allow_anonymous": True},
+        "samples.broker_dollar_topics.ClientDollarBroadcast": { },
+    }
+}
+
+async def main_loop():
+    broker = Broker(config)
+    try:
+        await broker.start()
+        while True:
+            await asyncio.sleep(1)
+    except asyncio.CancelledError:
+        await broker.shutdown()
+
+async def main():
+    t = asyncio.create_task(main_loop())
+    try:
+        await t
+    except asyncio.CancelledError:
+        pass
+
+def __main__():
+
+    formatter = "[%(asctime)s] :: %(levelname)s :: %(name)s :: %(message)s"
+    logging.basicConfig(level=logging.INFO, format=formatter)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    task = loop.create_task(main())
+
+    try:
+        loop.run_until_complete(task)
+    except KeyboardInterrupt:
+        logger.info("KeyboardInterrupt received. Stopping server...")
+        task.cancel()
+        loop.run_until_complete(task)  # Ensure task finishes cleanup
+    finally:
+        logger.info("Server stopped.")
+        loop.close()
+
+if __name__ == "__main__":
+    __main__()

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -362,4 +362,6 @@ async def test_allowable_dollar_topics():
     assert message.data == b'test message'
     await rcv_client.disconnect()
 
-    await asyncio.sleep(1)
+    await asyncio.sleep(0.1)
+    await broker.shutdown()
+    await asyncio.sleep(0.1)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+from amqtt.mqtt.constants import QOS_0
 from samples.http_server_integration import main as http_server_main
 from samples.unix_sockets import app as unix_sockets_app
 
@@ -17,6 +18,7 @@ from amqtt.broker import Broker
 from amqtt.client import MQTTClient
 from samples.broker_acl import config as broker_acl_config
 from samples.broker_taboo import config as broker_taboo_config
+from samples.broker_dollar_topics import config as broker_dollar_topics_config
 
 logger = logging.getLogger(__name__)
 
@@ -334,3 +336,30 @@ async def test_unix_connection():
     # verify that the broker received client connected/disconnected
     assert "on_broker_client_connected" in broker_stderr.decode("utf-8")
     assert "on_broker_client_disconnected" in broker_stderr.decode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_allowable_dollar_topics():
+
+    broker = Broker(config=broker_dollar_topics_config)
+    await broker.start()
+    await asyncio.sleep(1)
+
+    rcv_client = MQTTClient(config={'auto_reconnect': False})
+    await rcv_client.connect("ws://127.0.0.1:8080/mqtt")
+    await rcv_client.subscribe([("$my/dollar/topic", QOS_0),])
+    assert rcv_client.session is not None
+
+    pub_client = MQTTClient(config={'auto_reconnect': False})
+    await pub_client.connect("ws://127.0.0.1:8080/mqtt")
+    await pub_client.publish("$my/dollar/topic", b'test message')
+    await asyncio.sleep(1)
+    await pub_client.disconnect()
+
+    message = await rcv_client.deliver_message()
+    assert message is not None
+    assert message.publish_packet is not None
+    assert message.data == b'test message'
+    await rcv_client.disconnect()
+
+    await asyncio.sleep(1)

--- a/tests/test_session_monitor.py
+++ b/tests/test_session_monitor.py
@@ -58,3 +58,4 @@ async def test_clear_session_expiration(caplog, session_broker_config, username,
         assert any([record for record in caplog.records if "Expired 1 sessions" in record.message]) == (session_count == 0)
 
     await broker.shutdown()
+    await asyncio.sleep(0.5)

--- a/tests/test_session_monitor.py
+++ b/tests/test_session_monitor.py
@@ -58,4 +58,4 @@ async def test_clear_session_expiration(caplog, session_broker_config, username,
         assert any([record for record in caplog.records if "Expired 1 sessions" in record.message]) == (session_count == 0)
 
     await broker.shutdown()
-    await asyncio.sleep(0.5)
+    await asyncio.sleep(0.1)


### PR DESCRIPTION
### Changes included in this PR

Instead of adding functionality via primary configuration ( PR #314 ), add via a custom plugin.

### Current behavior

publishing by clients to `$` topics is restricted per MQTT-4.7.2-1 

however, the broker does inform plugins of all incoming messages. so if a plugin would like to publish a message on a topic that is normally restricted, it can use the public functions within the `context`.

### New behavior

broker maintains its compliance with MQTT 3.1.1 but use can be implemented via plugin.

### Impact

no breaking changes. added an example.

### Checklist

1. [X ] Does your submission pass the existing tests?
2. [X ] Are there new tests that cover these additions/changes?
3. [X ] Have you linted your code locally before submission?
