### PR TITLE
adding support to the persistence plugin for other db backends

### DIFF
--- a/amqtt/contrib/persistence.py
+++ b/amqtt/contrib/persistence.py
@@ -75,23 +75,25 @@ class SessionDBPlugin(BasePlugin[BrokerContext]):
         super().__init__(context)
 
         connection = self.config.connection
+        configured_file = getattr(self.config, "file", None)
 
-        if getattr(self.config, "file", None) and connection:
+        if configured_file and connection:
             msg = "`Config` requires file _or_ connection, but not both."
             raise PluginInitError(msg)
 
         # backwards compatibility support for `file` option
-        if not hasattr(self.config, "file") and not connection:
-            connection = "sqlite+aiosqlite:///amqtt.db"
-
-        if getattr(self.config, "file", None):
-            connection = f"sqlite+aiosqlite:///{self.config.file}"
+        if configured_file:
+            connection = f"sqlite+aiosqlite:///{configured_file}"
             warnings.warn(
                 "persistence plugin: `file` option is now deprecated, use full `connection` string instead."
                 " existing configurations will continue to work.",
                 DeprecationWarning,
                 stacklevel=0
             )
+        elif not connection:
+            self.config.file = Path("amqtt.db")
+            connection = f"sqlite+aiosqlite:///{self.config.file}"
+
         self._engine = create_async_engine(connection)
         self._db_session_maker = async_sessionmaker(self._engine, expire_on_commit=False)
 
@@ -255,13 +257,25 @@ class SessionDBPlugin(BasePlugin[BrokerContext]):
         logger.info(f"Restored {restored_sessions} sessions.")
 
     async def on_broker_pre_shutdown(self) -> None:
-        """Clean up the db connection."""
-        await self._engine.dispose()
+        """Handle broker pre-shutdown event."""
 
     async def on_broker_post_shutdown(self) -> None:
 
-        if self.config.clear_on_shutdown and self.config.file.exists():
-            self.config.file.unlink()
+        try:
+            if not self.config.clear_on_shutdown:
+                return
+
+            if self.config.file:
+                await self._engine.dispose()
+                if self.config.file.exists():
+                    self.config.file.unlink()
+                return
+
+            async with self._engine.begin() as conn:
+                for table in reversed(Base.metadata.sorted_tables):
+                    await conn.execute(table.delete())
+        finally:
+            await self._engine.dispose()
 
     @dataclass
     class Config:
@@ -281,7 +295,7 @@ class SessionDBPlugin(BasePlugin[BrokerContext]):
         """
 
         clear_on_shutdown: bool = True
-        """if the broker shutdowns down normally, don't retain any information."""
+        """if the broker shutdowns down normally, clear retained persistence data."""
 
         def __post_init__(self) -> None:
             """Create `Path` from string path."""

--- a/amqtt/contrib/persistence.py
+++ b/amqtt/contrib/persistence.py
@@ -261,14 +261,14 @@ class SessionDBPlugin(BasePlugin[BrokerContext]):
     class Config:
         """Configuration variables."""
 
-        connection: str = None
+        connection: str | None = None
         """SQLAlchemy connection string for the asyncio version of the database connector:
 
         - `mysql+aiomysql://user:password@host:port/dbname`
         - `postgresql+asyncpg://user:password@host:port/dbname`
         - `sqlite+aiosqlite:///dbfilename.db`
         """
-        file: str | Path = "amqtt.db"
+        file: str | Path | None = "amqtt.db"
         """path & filename to store the sqlite session db
         Deprecated in 0.11.4, use `connection` instead.
         """

--- a/amqtt/contrib/persistence.py
+++ b/amqtt/contrib/persistence.py
@@ -74,11 +74,16 @@ class SessionDBPlugin(BasePlugin[BrokerContext]):
     def __init__(self, context: BrokerContext) -> None:
         super().__init__(context)
 
-        # bypass the `test_plugins_correct_has_attr` until it can be updated
-        if getattr(self.config, "file", None) and getattr(self.config, "connection", None):
-            msg = "`Config` supports file _or_ connection, not both."
-            raise PluginInitError(msg)
         connection = self.config.connection
+
+        # backwards compatibility support
+        if not hasattr(self.config, "file") and not connection:
+            connection = f"sqlite+aiosqlite:///amqtt.db"
+
+        if getattr(self.config, "file", None) and connection:
+            msg = "`Config` requires file _or_ connection, but not both."
+            raise PluginInitError(msg)
+
         if getattr(self.config, "file", None):
             connection = f"sqlite+aiosqlite:///{self.config.file}"
             warnings.warn(
@@ -268,7 +273,7 @@ class SessionDBPlugin(BasePlugin[BrokerContext]):
         - `postgresql+asyncpg://user:password@host:port/dbname`
         - `sqlite+aiosqlite:///dbfilename.db`
         """
-        file: str | Path | None = "amqtt.db"
+        file: str | Path | None = None
         """path & filename to store the sqlite session db
         Deprecated in 0.11.4, use `connection` instead.
         """

--- a/amqtt/contrib/persistence.py
+++ b/amqtt/contrib/persistence.py
@@ -78,7 +78,7 @@ class SessionDBPlugin(BasePlugin[BrokerContext]):
 
         # backwards compatibility support
         if not hasattr(self.config, "file") and not connection:
-            connection = f"sqlite+aiosqlite:///amqtt.db"
+            connection = "sqlite+aiosqlite:///amqtt.db"
 
         if getattr(self.config, "file", None) and connection:
             msg = "`Config` requires file _or_ connection, but not both."

--- a/amqtt/contrib/persistence.py
+++ b/amqtt/contrib/persistence.py
@@ -1,14 +1,15 @@
 from dataclasses import dataclass
 import logging
 from pathlib import Path
+import warnings
 
-from sqlalchemy import Boolean, Integer, LargeBinary, Result, String, select
+from sqlalchemy import Boolean, Integer, LargeBinary, Result, Text, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from amqtt.broker import BrokerContext, RetainedApplicationMessage
 from amqtt.contrib import DataClassListJSON
-from amqtt.errors import PluginError
+from amqtt.errors import PluginError, PluginInitError
 from amqtt.plugins.base import BasePlugin
 from amqtt.session import Session
 
@@ -36,7 +37,7 @@ class StoredSession(Base):
     __tablename__ = "stored_sessions"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    client_id: Mapped[str] = mapped_column(String)
+    client_id: Mapped[str] = mapped_column(Text)
 
     clean_session: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
@@ -45,7 +46,7 @@ class StoredSession(Base):
     will_message: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True, default=None)
     will_qos: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
     will_retain: Mapped[bool | None] = mapped_column(Boolean, nullable=True, default=None)
-    will_topic: Mapped[str | None] = mapped_column(String, nullable=True, default=None)
+    will_topic: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
 
     keep_alive: Mapped[int] = mapped_column(Integer, default=0)
     retained: Mapped[list[RetainedMessage]] = mapped_column(DataClassListJSON(RetainedMessage), default=list)
@@ -56,7 +57,7 @@ class StoredMessage(Base):
     __tablename__ = "stored_messages"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    topic: Mapped[str] = mapped_column(String)
+    topic: Mapped[str] = mapped_column(Text)
     data: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True, default=None)
     qos: Mapped[int] = mapped_column(Integer, default=0)
 
@@ -74,11 +75,18 @@ class SessionDBPlugin(BasePlugin[BrokerContext]):
         super().__init__(context)
 
         # bypass the `test_plugins_correct_has_attr` until it can be updated
-        if not hasattr(self.config, "file"):
-            logger.warning("`Config` is missing a `file` attribute")
-            return
-
-        self._engine = create_async_engine(f"sqlite+aiosqlite:///{self.config.file}")
+        if getattr(self.config, "file", None) and getattr(self.config, "connection", None):
+            msg = "`Config` supports file _or_ connection, not both."
+            raise PluginInitError(msg)
+        connection = self.config.connection
+        if getattr(self.config, "file", None):
+            connection = f"sqlite+aiosqlite:///{self.config.file}"
+            warnings.warn(
+                "persistence plugin: `file` option is now deprecated, use full `connection` string instead",
+                DeprecationWarning,
+                stacklevel=0
+            )
+        self._engine = create_async_engine(connection)
         self._db_session_maker = async_sessionmaker(self._engine, expire_on_commit=False)
 
     @staticmethod
@@ -253,8 +261,18 @@ class SessionDBPlugin(BasePlugin[BrokerContext]):
     class Config:
         """Configuration variables."""
 
+        connection: str = None
+        """SQLAlchemy connection string for the asyncio version of the database connector:
+
+        - `mysql+aiomysql://user:password@host:port/dbname`
+        - `postgresql+asyncpg://user:password@host:port/dbname`
+        - `sqlite+aiosqlite:///dbfilename.db`
+        """
         file: str | Path = "amqtt.db"
-        """path & filename to store the sqlite session db."""
+        """path & filename to store the sqlite session db
+        Deprecated in 0.11.4, use `connection` instead.
+        """
+
         clear_on_shutdown: bool = True
         """if the broker shutdowns down normally, don't retain any information."""
 

--- a/amqtt/contrib/persistence.py
+++ b/amqtt/contrib/persistence.py
@@ -76,18 +76,19 @@ class SessionDBPlugin(BasePlugin[BrokerContext]):
 
         connection = self.config.connection
 
-        # backwards compatibility support
-        if not hasattr(self.config, "file") and not connection:
-            connection = "sqlite+aiosqlite:///amqtt.db"
-
         if getattr(self.config, "file", None) and connection:
             msg = "`Config` requires file _or_ connection, but not both."
             raise PluginInitError(msg)
 
+        # backwards compatibility support for `file` option
+        if not hasattr(self.config, "file") and not connection:
+            connection = "sqlite+aiosqlite:///amqtt.db"
+
         if getattr(self.config, "file", None):
             connection = f"sqlite+aiosqlite:///{self.config.file}"
             warnings.warn(
-                "persistence plugin: `file` option is now deprecated, use full `connection` string instead",
+                "persistence plugin: `file` option is now deprecated, use full `connection` string instead."
+                " existing configurations will continue to work.",
                 DeprecationWarning,
                 stacklevel=0
             )
@@ -271,11 +272,12 @@ class SessionDBPlugin(BasePlugin[BrokerContext]):
 
         - `mysql+aiomysql://user:password@host:port/dbname`
         - `postgresql+asyncpg://user:password@host:port/dbname`
-        - `sqlite+aiosqlite:///dbfilename.db`
+        - `sqlite+aiosqlite:///amqtt.db`  # default
         """
         file: str | Path | None = None
         """path & filename to store the sqlite session db
         Deprecated in 0.11.4, use `connection` instead.
+        Existing configurations will continue to work.
         """
 
         clear_on_shutdown: bool = True

--- a/tests/contrib/test_persistence.py
+++ b/tests/contrib/test_persistence.py
@@ -48,6 +48,31 @@ async def db_session_factory(db_file):
     yield factory
 
 
+def assert_stored_sessions_table_initialized(db_file: Path) -> None:
+    conn = sqlite3.connect(str(db_file))
+    try:
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(stored_sessions);")
+        rows = cursor.fetchall()
+    finally:
+        conn.close()
+
+    column_names = [row[1] for row in rows]
+    assert len(column_names) > 1
+
+
+def table_row_count(db_file: Path, table_name: str) -> int:
+    conn = sqlite3.connect(str(db_file))
+    try:
+        cursor = conn.cursor()
+        cursor.execute(f"SELECT COUNT(*) FROM {table_name};")
+        count = cursor.fetchone()[0]
+    finally:
+        conn.close()
+
+    return count
+
+
 @pytest.mark.parametrize("dialect", [sqlite.dialect(), postgresql.dialect(), mysql.dialect()])
 def test_persistence_schema_compiles_for_supported_dialects(dialect):
     for table in Base.metadata.sorted_tables:
@@ -61,6 +86,7 @@ def test_persistence_statements_compile_for_supported_dialects(dialect):
         select(StoredMessage).where(StoredMessage.topic == "topic/1"),
         StoredSession.__table__.insert(),
         StoredMessage.__table__.delete().where(StoredMessage.topic == "topic/1"),
+        *[table.delete() for table in Base.metadata.sorted_tables],
     ]
 
     for statement in statements:
@@ -76,13 +102,69 @@ async def test_initialize_tables(db_file, broker_context):
 
     assert db_file.exists()
 
-    conn = sqlite3.connect(str(db_file))
-    cursor = conn.cursor()
-    table_name = 'stored_sessions'
-    cursor.execute(f"PRAGMA table_info({table_name});")
-    rows = cursor.fetchall()
-    column_names = [row[1] for row in rows]
-    assert len(column_names) > 1
+    assert_stored_sessions_table_initialized(db_file)
+
+
+@pytest.mark.asyncio
+async def test_legacy_file_config_initializes_sqlite_db(db_file, broker_context):
+    broker_context.config = SessionDBPlugin.Config(file=db_file)
+
+    with pytest.deprecated_call(match="`file` option is now deprecated"):
+        session_db_plugin = SessionDBPlugin(broker_context)
+    await session_db_plugin.on_broker_pre_start()
+
+    assert db_file.exists()
+    assert_stored_sessions_table_initialized(db_file)
+
+
+@pytest.mark.asyncio
+async def test_blank_file_config_initializes_default_sqlite_db(tmp_path, monkeypatch, broker_context):
+    monkeypatch.chdir(tmp_path)
+    db_file = tmp_path / "amqtt.db"
+    broker_context.config = SessionDBPlugin.Config()
+
+    session_db_plugin = SessionDBPlugin(broker_context)
+    await session_db_plugin.on_broker_pre_start()
+
+    assert db_file.exists()
+    assert_stored_sessions_table_initialized(db_file)
+
+
+@pytest.mark.asyncio
+async def test_clear_on_shutdown_deletes_legacy_sqlite_file(db_file, broker_context):
+    broker_context.config = SessionDBPlugin.Config(file=db_file)
+
+    with pytest.deprecated_call(match="`file` option is now deprecated"):
+        session_db_plugin = SessionDBPlugin(broker_context)
+    await session_db_plugin.on_broker_pre_start()
+
+    assert db_file.exists()
+
+    await session_db_plugin.on_broker_post_shutdown()
+
+    assert not db_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_clear_on_shutdown_clears_database_tables_for_connection(db_file, broker_context):
+    broker_context.config = SessionDBPlugin.Config(connection=f"sqlite+aiosqlite:///{db_file}")
+    session_db_plugin = SessionDBPlugin(broker_context)
+    await session_db_plugin.on_broker_pre_start()
+
+    async with session_db_plugin._db_session_maker() as db_session, db_session.begin():
+        db_session.add(StoredSession(client_id="client-1"))
+        db_session.add(StoredMessage(topic="topic/1", data=b"payload", qos=1))
+
+    assert table_row_count(db_file, "stored_sessions") == 1
+    assert table_row_count(db_file, "stored_messages") == 1
+
+    await session_db_plugin.on_broker_post_shutdown()
+
+    assert db_file.exists()
+    assert_stored_sessions_table_initialized(db_file)
+    assert table_row_count(db_file, "stored_sessions") == 0
+    assert table_row_count(db_file, "stored_messages") == 0
+
 
 @pytest.mark.asyncio
 async def test_create_stored_session(db_file, broker_context, db_session_factory):

--- a/tests/contrib/test_persistence.py
+++ b/tests/contrib/test_persistence.py
@@ -5,13 +5,15 @@ import sqlite3
 import pytest
 import aiosqlite
 
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy import select
+from sqlalchemy.dialects import mysql, postgresql, sqlite
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.schema import CreateTable
 
 from amqtt.broker import Broker, BrokerContext, RetainedApplicationMessage
 from amqtt.client import MQTTClient
 from amqtt.mqtt.constants import QOS_1
-from amqtt.contrib.persistence import SessionDBPlugin, Subscription, StoredSession, RetainedMessage
+from amqtt.contrib.persistence import Base, RetainedMessage, SessionDBPlugin, StoredMessage, StoredSession, Subscription
 from amqtt.session import Session
 
 formatter = "[%(asctime)s] %(name)s {%(filename)s:%(lineno)d} %(levelname)s - %(message)s"
@@ -45,6 +47,24 @@ async def db_session_factory(db_file):
     factory = async_sessionmaker(engine, expire_on_commit=False)
     yield factory
 
+
+@pytest.mark.parametrize("dialect", [sqlite.dialect(), postgresql.dialect(), mysql.dialect()])
+def test_persistence_schema_compiles_for_supported_dialects(dialect):
+    for table in Base.metadata.sorted_tables:
+        str(CreateTable(table).compile(dialect=dialect))
+
+
+@pytest.mark.parametrize("dialect", [sqlite.dialect(), postgresql.dialect(), mysql.dialect()])
+def test_persistence_statements_compile_for_supported_dialects(dialect):
+    statements = [
+        select(StoredSession).where(StoredSession.client_id == "client-1"),
+        select(StoredMessage).where(StoredMessage.topic == "topic/1"),
+        StoredSession.__table__.insert(),
+        StoredMessage.__table__.delete().where(StoredMessage.topic == "topic/1"),
+    ]
+
+    for statement in statements:
+        str(statement.compile(dialect=dialect))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
persistence plugin was updated to use sqlalchemy but only provided support for sqlite. Matching the configuration for the DB auth plugin, a `connection` config parameter accepts a full sqlalchemy connection string, supporting sqlite, mysql and postgres.

### Changes included in this PR

- added 'connection' configuration to persistence plugin
- 'file' configuration is still supported, but marked as deprecated; still defaults to `amqtt.db`
- can specify 'connection' or 'file' parameter, but not both

### Current behavior

support only for file-based, sqlite db backend

### New behavior

supports full sqlalchemy connection string which extends functionality to postgres and mysql db backends as well

### Impact

no breaking changes, if using the 'file' configuration for the persistence plugin, it will show a deprecation warning

### Checklist

1. [X] Does your submission pass the existing tests?
2. [X] Are there new tests that cover these additions/changes?
3. [X] Have you linted your code locally before submission?
