### PR TITLE
authentication failure should send connack

### DIFF
--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -484,7 +484,7 @@ class Broker:
             )
             raise AMQTTError(exc) from exc
         except MQTTError as exc:
-            self.logger.exception(
+            self.logger.warning(
                 f"Invalid connection from {format_client_message(address=remote_address, port=remote_port)}",
             )
             await writer.close()
@@ -547,9 +547,6 @@ class Broker:
     ) -> None:
         """Handle the lifecycle of a client session."""
         authenticated = await self._authenticate(client_session, self.listeners_config[listener_name])
-        if not authenticated:
-            await writer.close()
-            return
 
         if client_session.client_id is None:
             msg = "Client ID was not correctly created/set."
@@ -573,6 +570,11 @@ class Broker:
         self._sessions[client_session.client_id] = (client_session, handler)
 
         await handler.mqtt_connack_authorize(authenticated)
+
+        if not authenticated:
+            await writer.close()
+            return
+
         await self.plugins_manager.fire_event(BrokerEvents.CLIENT_CONNECTED,
                                               client_id=client_session.client_id,
                                               client_session=client_session)

--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -444,7 +444,7 @@ class Broker:
         remote_info = writer.get_peer_info()
         if remote_info is None:
             self.logger.warning("Remote info could not be retrieved from peer info")
-            await writer.close() # python 3.10 needs explicit close
+            await writer.close()  # python 3.10 needs explicit close
             server.release_connection()
             return
 

--- a/amqtt/client.py
+++ b/amqtt/client.py
@@ -140,11 +140,11 @@ class MQTTClient:
                 initial connection (optional, used only with websocket connections)
 
         Returns:
-            [CONNACK](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718033)'s return code
+            CONNACK's successful return code (0x0)
 
         Raises:
-            ConnectError: could not connect to broker
-
+            ConnectError: if connect to broker fails or CONNACK contains non-zero (unsuccessful)
+            [`ConnectError.return_code`](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc385349257)
         """
         additional_headers = additional_headers if additional_headers is not None else {}
         self.session = self._init_session(uri, cleansession, cafile, capath, cadata)

--- a/amqtt/client.py
+++ b/amqtt/client.py
@@ -145,6 +145,7 @@ class MQTTClient:
         Raises:
             ConnectError: if connect to broker fails or CONNACK contains non-zero (unsuccessful)
             [`ConnectError.return_code`](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc385349257)
+
         """
         additional_headers = additional_headers if additional_headers is not None else {}
         self.session = self._init_session(uri, cleansession, cafile, capath, cadata)

--- a/amqtt/plugins/sys/broker.py
+++ b/amqtt/plugins/sys/broker.py
@@ -133,7 +133,6 @@ class BrokerSysPlugin(BasePlugin[BrokerContext]):
         else:
             self.context.logger.debug("$SYS disabled")
 
-
     async def on_broker_pre_shutdown(self) -> None:
         """Stop $SYS topics broadcasting."""
         if self._sys_handle:

--- a/tests/plugins/test_authentication.py
+++ b/tests/plugins/test_authentication.py
@@ -5,6 +5,9 @@ import unittest
 
 import pytest
 
+from amqtt.broker import Broker
+from amqtt.client import MQTTClient
+from amqtt.errors import ConnectError
 from amqtt.plugins.authentication import AnonymousAuthPlugin, FileAuthPlugin
 from amqtt.contexts import BaseContext
 from amqtt.plugins.base import BaseAuthPlugin
@@ -127,3 +130,34 @@ class TestFileAuthPlugin(unittest.TestCase):
         auth_plugin = FileAuthPlugin(context)
         ret = self.loop.run_until_complete(auth_plugin.authenticate(session=s))
         assert not ret
+
+
+@pytest.mark.asyncio
+async def test_connack_failure_on_invalid_password():
+
+    config = {
+        "listeners": {
+            "default": {"type": "tcp", "bind": "127.0.0.1:1883", "max_connections": 10},
+        },
+        'plugins':[
+            {'amqtt.plugins.authentication.FileAuthPlugin': {
+                'password_file': Path(__file__).parent / "passwd"
+            }}
+        ]
+    }
+
+    broker = Broker(config=config)
+    await broker.start()
+    await asyncio.sleep(0.1)
+
+    client = MQTTClient(config={'auto_reconnect': False})
+
+    with pytest.raises(ConnectError) as exec:
+        ret = await client.connect("mqtt://user:badpass@127.0.0.1:1883/")
+
+    assert exec.value.return_code == 0x05
+
+    await client.disconnect()
+
+    await broker.shutdown()
+    await asyncio.sleep(0.1)


### PR DESCRIPTION
### Changes included in this PR

Fixes #334. if the broker establishes a connection with the client, but the protocol handshake fails, already connack with the correct return code. Under the case where the protocol handshake is ok, but the client fails to provide proper authentication credentials, the broker should send a connack as well.

Fixed the `client.connect` documentation to match functionality: returns with a success code (0x0) _or_ raises a `ConnectError` which contains the `return_code` for failed connections. 

Malformed client connections look like an exception, displaying a traceback, even though they're just a warning.

### Current behavior

Authentication failure causes client disconnection without the sending a `connack`

### New behavior

- Send a connack with [return code](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc385349257) of 0x5.
- a failed client connection no longer looks like a broker failure

### Impact

if a client fails authentication, it now receives the proper connack before the session is terminated

### Checklist

1. [X] Does your submission pass the existing tests?
2. [X] Are there new tests that cover these additions/changes?
3. [X] Have you linted your code locally before submission?
