### PR TITLE
fix: handle empty MQTT packet reads

### DIFF
--- a/amqtt/codecs_amqtt.py
+++ b/amqtt/codecs_amqtt.py
@@ -60,7 +60,7 @@ async def read_or_raise(reader: ReaderAdapter | asyncio.StreamReader, n: int = -
         data = await reader.read(n)
     except (asyncio.IncompleteReadError, ConnectionResetError, BrokenPipeError):
         data = None
-    if data is None:
+    if data is None or (n != 0 and not data):
         msg = "No more data"
         raise NoDataError(msg)
     return data

--- a/amqtt/mqtt/packet.py
+++ b/amqtt/mqtt/packet.py
@@ -87,7 +87,7 @@ class MQTTFixedHeader:
             multiplier, value = 1, 0
             buffer = bytearray()
             while True:
-                encoded_byte = await reader.read(1)
+                encoded_byte = await read_or_raise(reader, 1)
                 byte_value = unpack("!B", encoded_byte)[0]
                 buffer.append(byte_value)
                 value += (byte_value & 0x7F) * multiplier

--- a/tests/mqtt/test_packet.py
+++ b/tests/mqtt/test_packet.py
@@ -32,6 +32,18 @@ class TestMQTTFixedHeaderTest(unittest.TestCase):
         assert not header.flags & 1
         assert header.remaining_length == 268435455
 
+    def test_from_empty_stream(self):
+        header = self.loop.run_until_complete(
+            MQTTFixedHeader.from_stream(BufferReader(b"")),
+        )
+        assert header is None
+
+    def test_from_stream_without_remaining_length(self):
+        header = self.loop.run_until_complete(
+            MQTTFixedHeader.from_stream(BufferReader(b"\x10")),
+        )
+        assert header is None
+
     def test_from_bytes_ko_with_length(self):
         data = b"\x10\xff\xff\xff\xff\x7f"
         stream = BufferReader(data)


### PR DESCRIPTION
### Changes included in this PR

Treat empty and truncated MQTT fixed-header reads as end-of-stream instead of passing an empty buffer to `struct.unpack`. Remaining-length bytes now use the same guarded read path, with regression coverage for both cases.

### Current behavior

An empty read raises `struct.error` and is logged as an unhandled reader-coro exception. Closes #231.

### New behavior

The fixed-header decoder returns `None`, allowing the reader loop to close normally.

### Impact

No breaking changes.

### Checklist

1. [x] Does your submission pass the existing tests?
2. [x] Are there new tests that cover these additions/changes?
3. [x] Have you linted your code locally before submission?
