### PR TITLE
improving java tests to eliminate itermitent failures

### DIFF
--- a/tests/support/MqttInteropClient.java
+++ b/tests/support/MqttInteropClient.java
@@ -4,6 +4,9 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 
 public final class MqttInteropClient {
+    private static final long MQTT_OPERATION_TIMEOUT_MS = 5000L;
+    private static final long MQTT_DISCONNECT_QUIESCE_MS = 1000L;
+
     private MqttInteropClient() {
     }
 
@@ -38,9 +41,12 @@ public final class MqttInteropClient {
 
     private static void connect(String brokerUri, String clientId) throws Exception {
         MqttClient client = new MqttClient(brokerUri, clientId, null);
-        client.connect(connectOptions());
-        client.disconnect();
-        client.close();
+        client.setTimeToWait(MQTT_OPERATION_TIMEOUT_MS);
+        try {
+            client.connect(connectOptions());
+        } finally {
+            close(client);
+        }
     }
 
     private static void publish(
@@ -52,14 +58,17 @@ public final class MqttInteropClient {
             int count
     ) throws Exception {
         MqttClient client = new MqttClient(brokerUri, clientId, null);
-        client.connect(connectOptions());
-        for (int i = 0; i < count; i++) {
-            MqttMessage message = new MqttMessage(payload.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-            message.setQos(qos);
-            client.publish(topic, message);
+        client.setTimeToWait(MQTT_OPERATION_TIMEOUT_MS);
+        try {
+            client.connect(connectOptions());
+            for (int i = 0; i < count; i++) {
+                MqttMessage message = new MqttMessage(payload.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                message.setQos(qos);
+                client.publish(topic, message);
+            }
+        } finally {
+            close(client);
         }
-        client.disconnect();
-        client.close();
     }
 
     private static MqttConnectOptions connectOptions() {
@@ -68,5 +77,15 @@ public final class MqttInteropClient {
         options.setCleanSession(true);
         options.setConnectionTimeout(5);
         return options;
+    }
+
+    private static void close(MqttClient client) throws Exception {
+        try {
+            if (client.isConnected()) {
+                client.disconnect(MQTT_DISCONNECT_QUIESCE_MS);
+            }
+        } finally {
+            client.close(true);
+        }
     }
 }

--- a/tests/test_java_mqtt.py
+++ b/tests/test_java_mqtt.py
@@ -16,6 +16,7 @@ from amqtt.mqtt.constants import QOS_1, QOS_2
 pytestmark = pytest.mark.extended
 
 JAVA_CLIENT_SOURCE = Path(__file__).parent / "support" / "MqttInteropClient.java"
+JAVA_CLIENT_TIMEOUT_SECONDS = 10
 PAHO_JAR_GLOBS = (
     ".m2/repository/org/eclipse/paho/org.eclipse.paho.client.mqttv3/*/org.eclipse.paho.client.mqttv3-*.jar",
     ".gradle/caches/modules-2/files-2.1/org.eclipse.paho/org.eclipse.paho.client.mqttv3/*/*/org.eclipse.paho.client.mqttv3-*.jar",
@@ -70,22 +71,31 @@ def java_mqtt_client(tmp_path_factory: pytest.TempPathFactory, paho_mqtt_java_ja
 
 
 async def run_java_mqtt_client(classpath: str, *args: str) -> subprocess.CompletedProcess[str]:
-    proc = await asyncio.create_subprocess_exec(
+    command = [
         "java",
         "-cp",
         classpath,
         "MqttInteropClient",
         *args,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
-    completed = subprocess.CompletedProcess(
-        args=["java", "-cp", classpath, "MqttInteropClient", *args],
-        returncode=proc.returncode,
-        stdout=stdout.decode(),
-        stderr=stderr.decode(),
-    )
+    ]
+    try:
+        completed = await asyncio.to_thread(
+            subprocess.run,
+            command,
+            capture_output=True,
+            text=True,
+            timeout=JAVA_CLIENT_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout.decode(errors="replace") if isinstance(exc.stdout, bytes) else (exc.stdout or "")
+        stderr = exc.stderr.decode(errors="replace") if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+        raise AssertionError(
+            f"Java MQTT client timed out after {JAVA_CLIENT_TIMEOUT_SECONDS}s\n"
+            f"stdout:\n{stdout}\n"
+            f"stderr:\n{stderr}",
+        ) from exc
+
     assert completed.returncode == 0, (
         f"Java MQTT client failed with {completed.returncode}\n"
         f"stdout:\n{completed.stdout}\n"


### PR DESCRIPTION
### Changes included in this PR

java tests, during CI, fail intermittently. use asyncio.to_thread to capture any java failures to understand why there was a failure. 

### Current behavior

no change in behavior

### Checklist

1. [X] Does your submission pass the existing tests?
2. [X] Are there new tests that cover these additions/changes?
3. [X] Have you linted your code locally before submission?
