### PR TITLE
updating js-yaml to fix GHSA-5p4m-2wfm-xmqj vulnerability

### DIFF
--- a/docs_test/package-lock.json
+++ b/docs_test/package-lock.json
@@ -5627,9 +5627,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
### Changes included in this PR

updating js-yaml to fix GHSA-5p4m-2wfm-xmqj vulnerability

```
Vulnerabilities
score is 9: 1 existing vulnerabilities detected:
Warn: Project is vulnerable to: GHSA-5p4m-2wfm-xmqj
Click Remediation section below to solve this issue
```

https://github.com/Yakifo/amqtt/security/code-scanning/7

### Impact

v 4.3.0 --> v 4.3.1

### Checklist

1. [X] Does your submission pass the existing tests?
2. [X] Are there new tests that cover these additions/changes?
3. [X] Have you linted your code locally before submission?
