### PR TITLE
fixing `release-drafter` workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,8 @@
 ---
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
-template: ""
+# The release body comes entirely from the `header` input, which the workflow
+# fills with the most recent section of docs/changelog.md. `template` cannot be
+# empty -- the action's schema declares it `Joi.string().required()` with no
+# `.allow('')` -- so this is a deliberate no-op placeholder.
+template: " "

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -81,10 +81,25 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Take only the first "## " section -- the changelog is newest-first, so
+          # that is the release being drafted. Matching on position rather than on
+          # the tag name keeps this working whether the heading reads "0.12.0" or
+          # "0.12.0rc1". The heading itself is dropped, since the GitHub release
+          # already carries the version as its title.
+          notes="$(awk '
+            /^## / { if (found) exit; found = 1; next }
+            found
+          ' docs/changelog.md)"
+
+          if [[ -z "${notes//[[:space:]]/}" ]]; then
+            echo "::error file=docs/changelog.md::No release notes found under the first '## ' heading"
+            exit 1
+          fi
+
           delimiter="CHANGELOG_${RANDOM}_${RANDOM}"
           {
             echo "body<<$delimiter"
-            cat docs/changelog.md
+            printf '%s\n' "$notes"
             echo "$delimiter"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -73,6 +73,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          # Read the changelog from the tag being released, not from the default
+          # branch. On a tag push this is what checkout would pick anyway; stating
+          # it explicitly is what makes `workflow_dispatch` correct, so a release
+          # can be drafted from a tag whose content never landed on main.
+          ref: ${{ steps.release.outputs.tag }}
           persist-credentials: false
 
       - name: Read changelog


### PR DESCRIPTION
- only includes the most recent section of `docs/changelog.md`
- fixes a missing template variable