### PR TITLE
fix/broker shutdown

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,8 @@
 ---
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
-template: ""
+# The release body comes entirely from the `header` input, which the workflow
+# fills with the most recent section of docs/changelog.md. `template` cannot be
+# empty -- the action's schema declares it `Joi.string().required()` with no
+# `.allow('')` -- so this is a deliberate no-op placeholder.
+template: " "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
 
       # https://github.com/actions/setup-node
       - name: 🏗 Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "22"
           cache: npm
@@ -224,14 +224,14 @@ jobs:
 
       # https://github.com/actions/upload-artifact
       - name: Upload test report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pytest-report-${{ matrix.python-version }}
           path: pytest-report.xml
 
       # https://github.com/actions/upload-artifact
       - name: Upload coverage results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-results-${{ matrix.python-version }}
           path: coverage.xml

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -151,7 +151,7 @@ jobs:
 
       # https://github.com/actions/upload-artifact
       - name: Upload distributions
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -81,10 +81,25 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Take only the first "## " section -- the changelog is newest-first, so
+          # that is the release being drafted. Matching on position rather than on
+          # the tag name keeps this working whether the heading reads "0.12.0" or
+          # "0.12.0rc1". The heading itself is dropped, since the GitHub release
+          # already carries the version as its title.
+          notes="$(awk '
+            /^## / { if (found) exit; found = 1; next }
+            found
+          ' docs/changelog.md)"
+
+          if [[ -z "${notes//[[:space:]]/}" ]]; then
+            echo "::error file=docs/changelog.md::No release notes found under the first '## ' heading"
+            exit 1
+          fi
+
           delimiter="CHANGELOG_${RANDOM}_${RANDOM}"
           {
             echo "body<<$delimiter"
-            cat docs/changelog.md
+            printf '%s\n' "$notes"
             echo "$delimiter"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -73,6 +73,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          # Read the changelog from the tag being released, not from the default
+          # branch. On a tag push this is what checkout would pick anyway; stating
+          # it explicitly is what makes `workflow_dispatch` correct, so a release
+          # can be drafted from a tag whose content never landed on main.
+          ref: ${{ steps.release.outputs.tag }}
           persist-credentials: false
 
       - name: Read changelog

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -42,7 +42,7 @@ jobs:
 
       # https://github.com/actions/upload-artifact
       - name: Upload SARIF artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: openssf-scorecard-sarif
           path: results.sarif

--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -259,11 +259,11 @@ class Broker:
             msg = f"Broker instance can't be started: {exc}"
             raise BrokerError(msg) from exc
 
-        await self.plugins_manager.fire_event(BrokerEvents.PRE_START)
+        await self.plugins_manager.fire_event(BrokerEvents.PRE_START, wait=True)
         try:
             await self._start_listeners()
             self.transitions.starting_success()
-            await self.plugins_manager.fire_event(BrokerEvents.POST_START)
+            await self.plugins_manager.fire_event(BrokerEvents.POST_START, wait=True)
             self._broadcast_task = asyncio.ensure_future(self._broadcast_loop())
             self._session_monitor_task = asyncio.create_task(self._session_monitor())
             self.logger.debug("Broker started")
@@ -385,7 +385,7 @@ class Broker:
         """Stop broker instance."""
         self.logger.info("Shutting down broker...")
         # Fire broker_shutdown event to plugins
-        await self.plugins_manager.fire_event(BrokerEvents.PRE_SHUTDOWN)
+        await self.plugins_manager.fire_event(BrokerEvents.PRE_SHUTDOWN, wait=True)
 
         # Cleanup all sessions
         for client_id in list(self._sessions.keys()):
@@ -411,7 +411,9 @@ class Broker:
                 self._broadcast_queue.get_nowait()
 
         self.logger.info("Broker closed")
-        await self.plugins_manager.fire_event(BrokerEvents.POST_SHUTDOWN)
+        await self.plugins_manager.wait_fired_events()
+        await self.plugins_manager.fire_event(BrokerEvents.POST_SHUTDOWN, wait=True)
+        await self.plugins_manager.close()
         self.transitions.stopping_success()
 
     async def _cleanup_session(self, client_id: str) -> None:

--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -37,6 +37,7 @@ _BROADCAST: TypeAlias = dict[str, Session | str | bytes | bytearray | int | None
 # Default port numbers
 DEFAULT_PORTS = {"tcp": 1883, "ws": 8883}
 AMQTT_MAGIC_VALUE_RET_SUBSCRIBED = 0x80
+_BROADCAST_SHUTDOWN_TIMEOUT = 5
 
 
 class RetainedApplicationMessage(ApplicationMessage):
@@ -647,10 +648,10 @@ class Broker:
                 self.logger.debug("Client loop cancelled")
                 break
 
-        disconnect_waiter.cancel()
-        subscribe_waiter.cancel()
-        unsubscribe_waiter.cancel()
-        wait_deliver.cancel()
+        pending_waiters = [disconnect_waiter, subscribe_waiter, unsubscribe_waiter, wait_deliver]
+        for waiter in pending_waiters:
+            waiter.cancel()
+        await asyncio.gather(*pending_waiters, return_exceptions=True)
 
     async def _handle_disconnect(
         self,
@@ -980,15 +981,29 @@ class Broker:
                 # Shutdown has been triggered by the broker, so stop the loop execution
                 if self._broadcast_shutdown_waiter in completed:
                     run_broadcast_task.cancel()
+                    await asyncio.gather(run_broadcast_task, return_exceptions=True)
                     break
 
         except BaseException:
             self.logger.exception("Broadcast loop stopped by exception")
             raise
         finally:
-            # Wait until current broadcasting tasks end
             if running_tasks:
-                await asyncio.gather(*running_tasks)
+                for task in running_tasks:
+                    if not task.done():
+                        task.cancel()
+
+                done, pending = await asyncio.wait(running_tasks, timeout=_BROADCAST_SHUTDOWN_TIMEOUT)
+                for task in done:
+                    try:
+                        task.result()
+                    except CancelledError:
+                        self.logger.info(f"Task has been cancelled: {task}")
+                    except Exception:
+                        self.logger.exception(f"Task failed during broadcast shutdown: {task}")
+
+                if pending:
+                    self.logger.warning(f"{len(pending)} broadcast task(s) still pending after shutdown")
 
     async def _run_broadcast(self, running_tasks: deque[asyncio.Task[OutgoingApplicationMessage]]) -> None:
         """Process a single broadcast message."""
@@ -1064,10 +1079,21 @@ class Broker:
     async def _shutdown_broadcast_loop(self) -> None:
         if self._broadcast_task and not self._broadcast_shutdown_waiter.done():
             self._broadcast_shutdown_waiter.set_result(True)
-            try:
-                await asyncio.wait_for(self._broadcast_task, timeout=30)
-            except TimeoutError as e:
-                self.logger.warning(f"Failed to cleanly shutdown broadcast loop: {e}")
+            for task in self._tasks_queue:
+                if not task.done():
+                    task.cancel()
+            done, pending = await asyncio.wait([self._broadcast_task], timeout=_BROADCAST_SHUTDOWN_TIMEOUT)
+            for task in done:
+                try:
+                    task.result()
+                except CancelledError:
+                    self.logger.info(f"Broadcast task has been cancelled: {task}")
+                except Exception:
+                    self.logger.exception(f"Broadcast task failed during shutdown: {task}")
+            for task in pending:
+                task.cancel()
+            if pending:
+                self.logger.warning(f"Failed to cleanly shutdown broadcast loop within {_BROADCAST_SHUTDOWN_TIMEOUT} seconds")
 
         if not self._broadcast_queue.empty():
             self.logger.warning(f"{self._broadcast_queue.qsize()} messages not broadcasted")

--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -401,6 +401,7 @@ class Broker:
         await self._shutdown_broadcast_loop()
         if self._session_monitor_task:
             self._session_monitor_task.cancel()
+            await asyncio.gather(self._session_monitor_task, return_exceptions=True)
 
         for server in self._servers.values():
             await server.close_instance()

--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -999,7 +999,7 @@ class Broker:
                         task.result()
                     except CancelledError:
                         self.logger.info(f"Task has been cancelled: {task}")
-                    except Exception:
+                    except Exception:  # pylint: disable=W0718
                         self.logger.exception(f"Task failed during broadcast shutdown: {task}")
 
                 if pending:
@@ -1088,7 +1088,7 @@ class Broker:
                     task.result()
                 except CancelledError:
                     self.logger.info(f"Broadcast task has been cancelled: {task}")
-                except Exception:
+                except Exception:  # pylint: disable=W0718
                     self.logger.exception(f"Broadcast task failed during shutdown: {task}")
             for task in pending:
                 task.cancel()

--- a/amqtt/contrib/auth_db/managers.py
+++ b/amqtt/contrib/auth_db/managers.py
@@ -24,6 +24,10 @@ class UserManager:
         self._engine = create_async_engine(connection)
         self._db_session_maker = async_sessionmaker(self._engine, expire_on_commit=False)
 
+    async def close(self) -> None:
+        """Dispose the database engine."""
+        await self._engine.dispose()
+
     async def db_sync(self) -> None:
         """Sync the database schema."""
         async with self._engine.begin() as conn:
@@ -120,6 +124,10 @@ class TopicManager:
     def __init__(self, connection: str) -> None:
         self._engine = create_async_engine(connection)
         self._db_session_maker = async_sessionmaker(self._engine, expire_on_commit=False)
+
+    async def close(self) -> None:
+        """Dispose the database engine."""
+        await self._engine.dispose()
 
     async def db_sync(self) -> None:
         """Sync the database schema."""

--- a/amqtt/contrib/auth_db/managers.py
+++ b/amqtt/contrib/auth_db/managers.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterator
 import logging
+from typing_extensions import Self
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -27,6 +28,14 @@ class UserManager:
     async def close(self) -> None:
         """Dispose the database engine."""
         await self._engine.dispose()
+
+    async def __aenter__(self) -> Self:
+        """Enter the context, returning the manager itself."""
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        """Dispose the database engine on exit."""
+        await self.close()
 
     async def db_sync(self) -> None:
         """Sync the database schema."""
@@ -128,6 +137,14 @@ class TopicManager:
     async def close(self) -> None:
         """Dispose the database engine."""
         await self._engine.dispose()
+
+    async def __aenter__(self) -> Self:
+        """Enter the context, returning the manager itself."""
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        """Dispose the database engine on exit."""
+        await self.close()
 
     async def db_sync(self) -> None:
         """Sync the database schema."""

--- a/amqtt/contrib/auth_db/plugin.py
+++ b/amqtt/contrib/auth_db/plugin.py
@@ -1,12 +1,10 @@
 from dataclasses import dataclass, field
 import logging
 
-from sqlalchemy.ext.asyncio import create_async_engine
-
 from amqtt.broker import BrokerContext
 from amqtt.contexts import Action
 from amqtt.contrib.auth_db.managers import TopicManager, UserManager
-from amqtt.contrib.auth_db.models import Base, PasswordHasher
+from amqtt.contrib.auth_db.models import PasswordHasher
 from amqtt.errors import MQTTError
 from amqtt.plugins.base import BaseAuthPlugin, BaseTopicPlugin
 from amqtt.session import Session
@@ -28,14 +26,12 @@ class UserAuthDBPlugin(BaseAuthPlugin):
         PasswordHasher(schemes=self.config.hash_schemes)
 
         self._user_manager = UserManager(self.config.connection)
-        self._engine = create_async_engine(f"{self.config.connection}")
 
     async def on_broker_pre_start(self) -> None:
         """Sync the schema (if configured)."""
         if not self.config.sync_schema:
             return
-        async with self._engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
+        await self._user_manager.db_sync()
 
     async def authenticate(self, *, session: Session) -> bool | None:
         """Authenticate a client's session."""
@@ -47,7 +43,6 @@ class UserAuthDBPlugin(BaseAuthPlugin):
     async def close(self) -> None:
         """Dispose database resources."""
         await self._user_manager.close()
-        await self._engine.dispose()
 
     @dataclass
     class Config:
@@ -72,14 +67,12 @@ class TopicAuthDBPlugin(BaseTopicPlugin):
         super().__init__(context)
 
         self._topic_manager = TopicManager(self.config.connection)
-        self._engine = create_async_engine(f"{self.config.connection}")
 
     async def on_broker_pre_start(self) -> None:
         """Sync the schema (if configured)."""
         if not self.config.sync_schema:
             return
-        async with self._engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
+        await self._topic_manager.db_sync()
 
     async def topic_filtering(
         self, *, session: Session | None = None, topic: str | None = None, action: Action | None = None
@@ -98,7 +91,6 @@ class TopicAuthDBPlugin(BaseTopicPlugin):
     async def close(self) -> None:
         """Dispose database resources."""
         await self._topic_manager.close()
-        await self._engine.dispose()
 
     @dataclass
     class Config:

--- a/amqtt/contrib/auth_db/plugin.py
+++ b/amqtt/contrib/auth_db/plugin.py
@@ -44,6 +44,11 @@ class UserAuthDBPlugin(BaseAuthPlugin):
 
         return await self._user_manager.verify_user_auth_password(session.username, session.password)
 
+    async def close(self) -> None:
+        """Dispose database resources."""
+        await self._user_manager.close()
+        await self._engine.dispose()
+
     @dataclass
     class Config:
         """Configuration for DB authentication."""
@@ -89,6 +94,11 @@ class TopicAuthDBPlugin(BaseTopicPlugin):
             return False
 
         return topic in topic_list
+
+    async def close(self) -> None:
+        """Dispose database resources."""
+        await self._topic_manager.close()
+        await self._engine.dispose()
 
     @dataclass
     class Config:

--- a/amqtt/contrib/auth_db/topic_mgr_cli.py
+++ b/amqtt/contrib/auth_db/topic_mgr_cli.py
@@ -53,12 +53,12 @@ def db_sync(ctx: typer.Context) -> None:
     """
     async def run_sync() -> None:
         connect = db_connection_str(ctx.obj["type"], ctx.obj["username"], ctx.obj["host"], ctx.obj["port"], ctx.obj["filename"])
-        mgr = UserManager(connect)
-        try:
-            await mgr.db_sync()
-        except MQTTError as me:
-            logger.critical("Could not sync schema on db.")
-            raise typer.Exit(code=1) from me
+        async with UserManager(connect) as mgr:
+            try:
+                await mgr.db_sync()
+            except MQTTError as me:
+                logger.critical("Could not sync schema on db.")
+                raise typer.Exit(code=1) from me
     asyncio.run(run_sync())
     logger.info("Success: database synced.")
 
@@ -69,14 +69,14 @@ def list_clients(ctx: typer.Context) -> None:
 
     async def run_list() -> None:
         connect = db_connection_str(ctx.obj["type"], ctx.obj["username"], ctx.obj["host"], ctx.obj["port"], ctx.obj["filename"])
-        mgr = TopicManager(connect)
-        user_count = 0
-        for user in await mgr.list_topic_auths():
-            user_count += 1
-            logger.info(user)
+        async with TopicManager(connect) as mgr:
+            user_count = 0
+            for user in await mgr.list_topic_auths():
+                user_count += 1
+                logger.info(user)
 
-        if not user_count:
-            logger.info("No client authorizations exist.")
+            if not user_count:
+                logger.info("No client authorizations exist.")
 
     asyncio.run(run_list())
 
@@ -93,23 +93,23 @@ def add_topic_allowance(
 
         connect = db_connection_str(ctx.obj["type"], ctx.obj["username"], ctx.obj["host"], ctx.obj["port"],
                                     ctx.obj["filename"])
-        mgr = TopicManager(connect)
+        async with TopicManager(connect) as mgr:
 
-        with contextlib.suppress(MQTTError):
-            await mgr.create_topic_auth(client_id)
+            with contextlib.suppress(MQTTError):
+                await mgr.create_topic_auth(client_id)
 
-        topic_auth = await mgr.get_topic_auth(client_id)
-        if not topic_auth:
-            logger.info(f"Topic auth doesn't exist for '{client_id}'")
-            raise typer.Exit(code=1)
+            topic_auth = await mgr.get_topic_auth(client_id)
+            if not topic_auth:
+                logger.info(f"Topic auth doesn't exist for '{client_id}'")
+                raise typer.Exit(code=1)
 
-        if topic in [allowed_topic.topic for allowed_topic in topic_auth.get_topic_list(action)]:
-            logger.info(f"Topic '{topic}' already exists for '{action}'.")
-            raise typer.Exit(1)
+            if topic in [allowed_topic.topic for allowed_topic in topic_auth.get_topic_list(action)]:
+                logger.info(f"Topic '{topic}' already exists for '{action}'.")
+                raise typer.Exit(1)
 
-        await mgr.add_allowed_topic(client_id, topic, action)
+            await mgr.add_allowed_topic(client_id, topic, action)
 
-        logger.info(f"Success: topic '{topic}' added to {action} for '{client_id}'")
+            logger.info(f"Success: topic '{topic}' added to {action} for '{client_id}'")
 
     asyncio.run(run_add())
 
@@ -124,25 +124,25 @@ def remove_topic_allowance(ctx: typer.Context,
     async def run_remove() -> None:
         connect = db_connection_str(ctx.obj["type"], ctx.obj["username"], ctx.obj["host"], ctx.obj["port"],
                                     ctx.obj["filename"])
-        mgr = TopicManager(connect)
+        async with TopicManager(connect) as mgr:
 
-        topic_auth = await mgr.get_topic_auth(client_id)
+            topic_auth = await mgr.get_topic_auth(client_id)
 
-        if not topic_auth:
-            logger.info(f"client '{client_id}' doesn't exist.")
-            raise typer.Exit(1)
+            if not topic_auth:
+                logger.info(f"client '{client_id}' doesn't exist.")
+                raise typer.Exit(1)
 
-        if topic not in getattr(topic_auth, f"{action}_acl"):
-            logger.info(f"Error: topic '{topic}' not in the {action} allow list for {client_id}.")
-            raise typer.Exit(1)
+            if topic not in getattr(topic_auth, f"{action}_acl"):
+                logger.info(f"Error: topic '{topic}' not in the {action} allow list for {client_id}.")
+                raise typer.Exit(1)
 
-        try:
-            await mgr.remove_allowed_topic(client_id, topic, action)
-        except MQTTError as me:
-            logger.info(f"'Error: could not remove '{topic}' for client '{client_id}'.")
-            raise typer.Exit(1) from me
+            try:
+                await mgr.remove_allowed_topic(client_id, topic, action)
+            except MQTTError as me:
+                logger.info(f"'Error: could not remove '{topic}' for client '{client_id}'.")
+                raise typer.Exit(1) from me
 
-        logger.info(f"Success: removed topic '{topic}' from {action} for '{client_id}'")
+            logger.info(f"Success: removed topic '{topic}' from {action} for '{client_id}'")
 
     asyncio.run(run_remove())
 

--- a/amqtt/contrib/auth_db/topic_mgr_cli.py
+++ b/amqtt/contrib/auth_db/topic_mgr_cli.py
@@ -8,7 +8,7 @@ import typer
 
 from amqtt.contexts import Action
 from amqtt.contrib.auth_db import DBType, db_connection_str
-from amqtt.contrib.auth_db.managers import TopicManager, UserManager
+from amqtt.contrib.auth_db.managers import TopicManager
 from amqtt.errors import MQTTError
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -53,7 +53,7 @@ def db_sync(ctx: typer.Context) -> None:
     """
     async def run_sync() -> None:
         connect = db_connection_str(ctx.obj["type"], ctx.obj["username"], ctx.obj["host"], ctx.obj["port"], ctx.obj["filename"])
-        async with UserManager(connect) as mgr:
+        async with TopicManager(connect) as mgr:
             try:
                 await mgr.db_sync()
             except MQTTError as me:

--- a/amqtt/contrib/auth_db/user_mgr_cli.py
+++ b/amqtt/contrib/auth_db/user_mgr_cli.py
@@ -56,12 +56,12 @@ def db_sync(ctx: typer.Context) -> None:
     """
     async def run_sync() -> None:
         connect = db_connection_str(ctx.obj["type"], ctx.obj["username"], ctx.obj["host"], ctx.obj["port"], ctx.obj["filename"])
-        mgr = UserManager(connect)
-        try:
-            await mgr.db_sync()
-        except MQTTError as me:
-            logger.critical("Could not sync schema on db.")
-            raise typer.Exit(code=1) from me
+        async with UserManager(connect) as mgr:
+            try:
+                await mgr.db_sync()
+            except MQTTError as me:
+                logger.critical("Could not sync schema on db.")
+                raise typer.Exit(code=1) from me
 
     asyncio.run(run_sync())
     logger.info("Success: database synced.")
@@ -73,14 +73,14 @@ def list_user_auths(ctx: typer.Context) -> None:
 
     async def run_list() -> None:
         connect = db_connection_str(ctx.obj["type"], ctx.obj["username"], ctx.obj["host"], ctx.obj["port"], ctx.obj["filename"])
-        mgr = UserManager(connect)
-        user_count = 0
-        for user in await mgr.list_user_auths():
-            user_count += 1
-            logger.info(user)
+        async with UserManager(connect) as mgr:
+            user_count = 0
+            for user in await mgr.list_user_auths():
+                user_count += 1
+                logger.info(user)
 
-        if not user_count:
-            logger.info("No client authentications exist.")
+            if not user_count:
+                logger.info("No client authentications exist.")
 
     asyncio.run(run_list())
 
@@ -94,19 +94,19 @@ def create_user_auth(
     async def run_create() -> None:
         connect = db_connection_str(ctx.obj["type"], ctx.obj["username"], ctx.obj["host"], ctx.obj["port"],
                                     ctx.obj["filename"])
-        mgr = UserManager(connect)
-        client_password = typer.prompt("Enter the client's password", hide_input=True)
-        if not client_password.strip():
-            logger.info("Error: client password cannot be empty.")
-            raise typer.Exit(1)
+        async with UserManager(connect) as mgr:
+            client_password = typer.prompt("Enter the client's password", hide_input=True)
+            if not client_password.strip():
+                logger.info("Error: client password cannot be empty.")
+                raise typer.Exit(1)
 
-        user = await mgr.create_user_auth(client_id, client_password.strip())
+            user = await mgr.create_user_auth(client_id, client_password.strip())
 
-        if not user:
-            logger.info(f"Error: could not create user: {client_id}")
-            raise typer.Exit(code=1)
+            if not user:
+                logger.info(f"Error: could not create user: {client_id}")
+                raise typer.Exit(code=1)
 
-        logger.info(f"Success: created {user}")
+            logger.info(f"Success: created {user}")
 
     asyncio.run(run_create())
 
@@ -118,21 +118,21 @@ def remove_user_auth(ctx: typer.Context,
     async def run_remove() -> None:
         connect = db_connection_str(ctx.obj["type"], ctx.obj["username"], ctx.obj["host"], ctx.obj["port"],
                                     ctx.obj["filename"])
-        mgr = UserManager(connect)
-        user = await mgr.get_user_auth(client_id)
-        if not user:
-            logger.info(f"Error: client '{client_id}' does not exist.")
-            raise typer.Exit(1)
+        async with UserManager(connect) as mgr:
+            user = await mgr.get_user_auth(client_id)
+            if not user:
+                logger.info(f"Error: client '{client_id}' does not exist.")
+                raise typer.Exit(1)
 
-        if not typer.confirm(f"Please confirm the removal of '{client_id}'?"):
-            raise typer.Exit(0)
+            if not typer.confirm(f"Please confirm the removal of '{client_id}'?"):
+                raise typer.Exit(0)
 
-        user = await mgr.delete_user_auth(client_id)
-        if not user:
-            logger.info(f"Error: client '{client_id}' does not exist.")
-            raise typer.Exit(1)
+            user = await mgr.delete_user_auth(client_id)
+            if not user:
+                logger.info(f"Error: client '{client_id}' does not exist.")
+                raise typer.Exit(1)
 
-        logger.info(f"Success: '{user.username}' was removed.")
+            logger.info(f"Success: '{user.username}' was removed.")
 
     asyncio.run(run_remove())
 
@@ -150,9 +150,9 @@ def change_password(
             raise typer.Exit(1)
         connect = db_connection_str(ctx.obj["type"], ctx.obj["username"], ctx.obj["host"], ctx.obj["port"],
                                     ctx.obj["filename"])
-        mgr = UserManager(connect)
-        await mgr.update_user_auth_password(client_id, client_password.strip())
-        logger.info(f"Success: client '{client_id}' password updated.")
+        async with UserManager(connect) as mgr:
+            await mgr.update_user_auth_password(client_id, client_password.strip())
+            logger.info(f"Success: client '{client_id}' password updated.")
 
     asyncio.run(run_password())
 

--- a/amqtt/contrib/persistence.py
+++ b/amqtt/contrib/persistence.py
@@ -277,6 +277,10 @@ class SessionDBPlugin(BasePlugin[BrokerContext]):
         finally:
             await self._engine.dispose()
 
+    async def close(self) -> None:
+        """Dispose the database engine."""
+        await self._engine.dispose()
+
     @dataclass
     class Config:
         """Configuration variables."""

--- a/amqtt/contrib/shadows/plugin.py
+++ b/amqtt/contrib/shadows/plugin.py
@@ -58,6 +58,10 @@ class ShadowPlugin(BasePlugin[BrokerContext]):
         async with self._engine.begin() as conn:
             await sync_shadow_base(conn)
 
+    async def close(self) -> None:
+        """Dispose the database engine."""
+        await self._engine.dispose()
+
     @staticmethod
     def shadow_topic_match(topic: str) -> ShadowTopic | None:
         """Check if topic matches the shadow topic format."""

--- a/amqtt/mqtt/protocol/handler.py
+++ b/amqtt/mqtt/protocol/handler.py
@@ -140,7 +140,7 @@ class ProtocolHandler(Generic[C]):
         if self._keepalive_task:
             self._keepalive_task.cancel()
         self.logger.debug("Waiting for tasks to be stopped")
-        if self._reader_task and not self._reader_task.done():
+        if self._reader_task and self._reader_task is not asyncio.current_task() and not self._reader_task.done():
             self._reader_task.cancel()
             await self._reader_stopped.wait()
         self.logger.debug("Closing writer")

--- a/amqtt/plugins/manager.py
+++ b/amqtt/plugins/manager.py
@@ -282,10 +282,22 @@ class PluginManager(Generic[C]):
 
     async def close(self) -> None:
         """Free PluginManager resources and cancel pending event methods."""
+        await self.wait_fired_events()
         await self.map_plugin_close()
         for task in self._fired_events:
             task.cancel()
         self._fired_events.clear()
+
+    async def wait_fired_events(self) -> None:
+        """Wait for already-scheduled fire-and-forget plugin events to finish."""
+        fired_events = list(self._fired_events)
+        if not fired_events:
+            return
+
+        await asyncio.gather(*fired_events, return_exceptions=True)
+        for task in fired_events:
+            with contextlib.suppress(KeyError, ValueError):
+                self._fired_events.remove(task)
 
     @property
     def plugins(self) -> list["BasePlugin[C]"]:

--- a/samples/client_keepalive.py
+++ b/samples/client_keepalive.py
@@ -21,7 +21,7 @@ async def main() -> None:
     try:
         await client.connect("mqtt://localhost:1883/")
         logger.info("client connected")
-        await asyncio.sleep(15)
+        await asyncio.sleep(7)
     except CancelledError:
         pass
 

--- a/tests/contrib/test_db_plugin.py
+++ b/tests/contrib/test_db_plugin.py
@@ -60,6 +60,23 @@ async def topic_manager(password_hasher, db_connection):
         await tm.close()
 
 
+@pytest.fixture
+async def auth_plugin():
+    """Build auth db plugins, releasing their connection pools on teardown."""
+    plugins = []
+
+    def factory(plugin_cls, context):
+        plugin = plugin_cls(context=context)
+        plugins.append(plugin)
+        return plugin
+
+    try:
+        yield factory
+    finally:
+        for plugin in plugins:
+            await plugin.close()
+
+
 # ######################################
 # Tests for the UserAuthDBPlugin
 
@@ -151,7 +168,7 @@ async def test_remove_users(user_manager, db_file, db_connection):
     ("mypassword", "myotherpassword", False),
 ])
 @pytest.mark.asyncio
-async def test_db_auth(db_connection, user_manager, user_pwd, session_pwd, outcome):
+async def test_db_auth(db_connection, user_manager, auth_plugin, user_pwd, session_pwd, outcome):
 
     await user_manager.create_user_auth("myuser", user_pwd)
 
@@ -159,7 +176,7 @@ async def test_db_auth(db_connection, user_manager, user_pwd, session_pwd, outco
     broker_context.config = UserAuthDBPlugin.Config(
         connection=db_connection
     )
-    db_auth_plugin = UserAuthDBPlugin(context=broker_context)
+    db_auth_plugin = auth_plugin(UserAuthDBPlugin, broker_context)
 
     s = Session()
     s.username = "myuser"
@@ -169,7 +186,7 @@ async def test_db_auth(db_connection, user_manager, user_pwd, session_pwd, outco
 
 
 @pytest.mark.asyncio
-async def test_db_auth_rehashes_outdated_password_hash(user_manager, db_file, db_connection):
+async def test_db_auth_rehashes_outdated_password_hash(user_manager, db_file, db_connection, auth_plugin):
     bcrypt_hash = BcryptHasher().hash("mypassword")
 
     async with aiosqlite.connect(db_file) as db_conn:
@@ -182,7 +199,7 @@ async def test_db_auth_rehashes_outdated_password_hash(user_manager, db_file, db
 
     broker_context = BrokerContext(broker=Broker())
     broker_context.config = UserAuthDBPlugin.Config(connection=db_connection)
-    db_auth_plugin = UserAuthDBPlugin(context=broker_context)
+    db_auth_plugin = auth_plugin(UserAuthDBPlugin, broker_context)
 
     s = Session()
     s.username = "myuser"
@@ -462,7 +479,7 @@ async def test_remove_topic_wrong_action(db_file, user_manager, topic_manager, d
     ("my/#", "my/another/topic", True),
 ])
 @pytest.mark.asyncio
-async def test_topic_publish_filter_plugin(db_file, topic_manager, db_connection, acl_topic, msg_topic, outcome):
+async def test_topic_publish_filter_plugin(db_file, topic_manager, db_connection, auth_plugin, acl_topic, msg_topic, outcome):
     client_id = "myuser"
 
     user = await topic_manager.create_topic_auth(client_id)
@@ -474,7 +491,7 @@ async def test_topic_publish_filter_plugin(db_file, topic_manager, db_connection
     broker_context.config = TopicAuthDBPlugin.Config(
         connection=db_connection
     )
-    db_auth_plugin = TopicAuthDBPlugin(context=broker_context)
+    db_auth_plugin = auth_plugin(TopicAuthDBPlugin, broker_context)
 
     s = Session()
     s.username = client_id

--- a/tests/contrib/test_db_plugin.py
+++ b/tests/contrib/test_db_plugin.py
@@ -44,14 +44,20 @@ def db_connection(db_file):
 async def user_manager(password_hasher, db_connection):
     um = UserManager(db_connection)
     await um.db_sync()
-    yield um
+    try:
+        yield um
+    finally:
+        await um.close()
 
 
 @pytest.fixture
 async def topic_manager(password_hasher, db_connection):
     tm = TopicManager(db_connection)
     await tm.db_sync()
-    yield tm
+    try:
+        yield tm
+    finally:
+        await tm.close()
 
 
 # ######################################

--- a/tests/contrib/test_db_scripts.py
+++ b/tests/contrib/test_db_scripts.py
@@ -43,14 +43,20 @@ def db_connection(db_file):
 async def user_manager(password_hasher, db_connection):
     um = UserManager(db_connection)
     await um.db_sync()
-    yield um
+    try:
+        yield um
+    finally:
+        await um.close()
 
 
 @pytest.fixture
 async def topic_manager(password_hasher, db_connection):
     tm = TopicManager(db_connection)
     await tm.db_sync()
-    yield tm
+    try:
+        yield tm
+    finally:
+        await tm.close()
 
 
 @pytest.mark.parametrize("app,error_msg", [

--- a/tests/contrib/test_persistence.py
+++ b/tests/contrib/test_persistence.py
@@ -79,7 +79,25 @@ async def broker_context():
 async def db_session_factory(db_file):
     engine = create_async_engine(f"sqlite+aiosqlite:///{str(db_file)}")
     factory = async_sessionmaker(engine, expire_on_commit=False)
-    yield factory
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+async def session_db_plugin_factory():
+    plugins: list[SessionDBPlugin] = []
+
+    def make_plugin(context: BrokerContext) -> SessionDBPlugin:
+        plugin = SessionDBPlugin(context)
+        plugins.append(plugin)
+        return plugin
+
+    yield make_plugin
+
+    for plugin in reversed(plugins):
+        await plugin.close()
 
 
 def assert_stored_sessions_table_initialized(db_file: Path) -> None:
@@ -128,10 +146,10 @@ def test_persistence_statements_compile_for_supported_dialects(dialect):
 
 
 @pytest.mark.asyncio
-async def test_initialize_tables(db_file, broker_context):
+async def test_initialize_tables(db_file, broker_context, session_db_plugin_factory):
 
     broker_context.config = SessionDBPlugin.Config(file=db_file)
-    session_db_plugin = SessionDBPlugin(broker_context)
+    session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     assert db_file.exists()
@@ -140,11 +158,11 @@ async def test_initialize_tables(db_file, broker_context):
 
 
 @pytest.mark.asyncio
-async def test_legacy_file_config_initializes_sqlite_db(db_file, broker_context):
+async def test_legacy_file_config_initializes_sqlite_db(db_file, broker_context, session_db_plugin_factory):
     broker_context.config = SessionDBPlugin.Config(file=db_file)
 
     with pytest.deprecated_call(match="`file` option is now deprecated"):
-        session_db_plugin = SessionDBPlugin(broker_context)
+        session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     assert db_file.exists()
@@ -152,12 +170,12 @@ async def test_legacy_file_config_initializes_sqlite_db(db_file, broker_context)
 
 
 @pytest.mark.asyncio
-async def test_blank_file_config_initializes_default_sqlite_db(tmp_path, monkeypatch, broker_context):
+async def test_blank_file_config_initializes_default_sqlite_db(tmp_path, monkeypatch, broker_context, session_db_plugin_factory):
     monkeypatch.chdir(tmp_path)
     db_file = tmp_path / "amqtt.db"
     broker_context.config = SessionDBPlugin.Config()
 
-    session_db_plugin = SessionDBPlugin(broker_context)
+    session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     assert db_file.exists()
@@ -165,11 +183,11 @@ async def test_blank_file_config_initializes_default_sqlite_db(tmp_path, monkeyp
 
 
 @pytest.mark.asyncio
-async def test_clear_on_shutdown_deletes_legacy_sqlite_file(db_file, broker_context):
+async def test_clear_on_shutdown_deletes_legacy_sqlite_file(db_file, broker_context, session_db_plugin_factory):
     broker_context.config = SessionDBPlugin.Config(file=db_file)
 
     with pytest.deprecated_call(match="`file` option is now deprecated"):
-        session_db_plugin = SessionDBPlugin(broker_context)
+        session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     assert db_file.exists()
@@ -180,9 +198,9 @@ async def test_clear_on_shutdown_deletes_legacy_sqlite_file(db_file, broker_cont
 
 
 @pytest.mark.asyncio
-async def test_clear_on_shutdown_clears_database_tables_for_connection(db_file, broker_context):
+async def test_clear_on_shutdown_clears_database_tables_for_connection(db_file, broker_context, session_db_plugin_factory):
     broker_context.config = SessionDBPlugin.Config(connection=f"sqlite+aiosqlite:///{db_file}")
-    session_db_plugin = SessionDBPlugin(broker_context)
+    session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     async with session_db_plugin._db_session_maker() as db_session, db_session.begin():
@@ -201,10 +219,10 @@ async def test_clear_on_shutdown_clears_database_tables_for_connection(db_file, 
 
 
 @pytest.mark.asyncio
-async def test_create_stored_session(db_file, broker_context, db_session_factory):
+async def test_create_stored_session(db_file, broker_context, db_session_factory, session_db_plugin_factory):
 
     broker_context.config = SessionDBPlugin.Config(file=db_file)
-    session_db_plugin = SessionDBPlugin(broker_context)
+    session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     async with db_session_factory() as db_session:
@@ -218,9 +236,9 @@ async def test_create_stored_session(db_file, broker_context, db_session_factory
                 assert row[1] == 'test_client_1'
 
 @pytest.mark.asyncio
-async def test_get_stored_session(db_file, broker_context, db_session_factory):
+async def test_get_stored_session(db_file, broker_context, db_session_factory, session_db_plugin_factory):
     broker_context.config = SessionDBPlugin.Config(file=db_file)
-    session_db_plugin = SessionDBPlugin(broker_context)
+    session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     async with aiosqlite.connect(str(db_file)) as db:
@@ -247,7 +265,7 @@ async def test_get_stored_session(db_file, broker_context, db_session_factory):
 
 
 @pytest.mark.asyncio
-async def test_update_stored_session(db_file, broker_context, db_session_factory):
+async def test_update_stored_session(db_file, broker_context, db_session_factory, session_db_plugin_factory):
     broker_context.config = SessionDBPlugin.Config(file=db_file)
 
     # create session for client id (without subscription)
@@ -257,7 +275,7 @@ async def test_update_stored_session(db_file, broker_context, db_session_factory
     assert session is not None
     session.clean_session = False
 
-    session_db_plugin = SessionDBPlugin(broker_context)
+    session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     # initialize with stored client session
@@ -292,10 +310,12 @@ async def test_update_stored_session(db_file, broker_context, db_session_factory
 
 
 @pytest.mark.asyncio
-async def test_client_connected_with_clean_session(db_file, broker_context, db_session_factory) -> None:
+async def test_client_connected_with_clean_session(
+    db_file, broker_context, db_session_factory, session_db_plugin_factory
+) -> None:
 
     broker_context.config = SessionDBPlugin.Config(file=db_file)
-    session_db_plugin = SessionDBPlugin(broker_context)
+    session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     session = Session()
@@ -313,10 +333,12 @@ async def test_client_connected_with_clean_session(db_file, broker_context, db_s
 
 
 @pytest.mark.asyncio
-async def test_client_connected_anonymous_session(db_file, broker_context, db_session_factory) -> None:
+async def test_client_connected_anonymous_session(
+    db_file, broker_context, db_session_factory, session_db_plugin_factory
+) -> None:
 
     broker_context.config = SessionDBPlugin.Config(file=db_file)
-    session_db_plugin = SessionDBPlugin(broker_context)
+    session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     session = Session()
@@ -332,10 +354,12 @@ async def test_client_connected_anonymous_session(db_file, broker_context, db_se
 
 
 @pytest.mark.asyncio
-async def test_client_connected_and_stored_session(db_file, broker_context, db_session_factory) -> None:
+async def test_client_connected_and_stored_session(
+    db_file, broker_context, db_session_factory, session_db_plugin_factory
+) -> None:
 
     broker_context.config = SessionDBPlugin.Config(file=db_file)
-    session_db_plugin = SessionDBPlugin(broker_context)
+    session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     session = Session()
@@ -370,10 +394,10 @@ async def test_client_connected_and_stored_session(db_file, broker_context, db_s
 
 
 @pytest.mark.asyncio
-async def test_repopulate_stored_sessions(db_file, broker_context, db_session_factory) -> None:
+async def test_repopulate_stored_sessions(db_file, broker_context, db_session_factory, session_db_plugin_factory) -> None:
 
     broker_context.config = SessionDBPlugin.Config(file=db_file)
-    session_db_plugin = SessionDBPlugin(broker_context)
+    session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     async with aiosqlite.connect(str(db_file)) as db:
@@ -406,10 +430,10 @@ async def test_repopulate_stored_sessions(db_file, broker_context, db_session_fa
 
 
 @pytest.mark.asyncio
-async def test_client_retained_message(db_file, broker_context, db_session_factory) -> None:
+async def test_client_retained_message(db_file, broker_context, db_session_factory, session_db_plugin_factory) -> None:
 
     broker_context.config = SessionDBPlugin.Config(file=db_file)
-    session_db_plugin = SessionDBPlugin(broker_context)
+    session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     # add a session to the broker
@@ -435,10 +459,10 @@ async def test_client_retained_message(db_file, broker_context, db_session_facto
 
 
 @pytest.mark.asyncio
-async def test_topic_retained_message(db_file, broker_context, db_session_factory) -> None:
+async def test_topic_retained_message(db_file, broker_context, db_session_factory, session_db_plugin_factory) -> None:
 
     broker_context.config = SessionDBPlugin.Config(file=db_file, clear_on_shutdown=False)
-    session_db_plugin = SessionDBPlugin(broker_context)
+    session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     # add a session to the broker
@@ -470,10 +494,12 @@ async def test_topic_retained_message(db_file, broker_context, db_session_factor
 
 
 @pytest.mark.asyncio
-async def test_topic_clear_retained_message(db_file, broker_context, db_session_factory) -> None:
+async def test_topic_clear_retained_message(
+    db_file, broker_context, db_session_factory, session_db_plugin_factory
+) -> None:
 
     broker_context.config = SessionDBPlugin.Config(file=db_file)
-    session_db_plugin = SessionDBPlugin(broker_context)
+    session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     # add a session to the broker
@@ -497,10 +523,10 @@ async def test_topic_clear_retained_message(db_file, broker_context, db_session_
 
 
 @pytest.mark.asyncio
-async def test_restoring_retained_message(db_file, broker_context, db_session_factory) -> None:
+async def test_restoring_retained_message(db_file, broker_context, db_session_factory, session_db_plugin_factory) -> None:
 
     broker_context.config = SessionDBPlugin.Config(file=db_file)
-    session_db_plugin = SessionDBPlugin(broker_context)
+    session_db_plugin = session_db_plugin_factory(broker_context)
     await session_db_plugin.on_broker_pre_start()
 
     stmts = ("INSERT INTO stored_messages VALUES(1,'my/retained/topic1',X'72657461696e6564206d657373616765',2)",

--- a/tests/contrib/test_shadows.py
+++ b/tests/contrib/test_shadows.py
@@ -36,7 +36,10 @@ async def db_session_maker(db_connection):
     engine = create_async_engine(f"{db_connection}")
     db_session_maker = async_sessionmaker(engine, expire_on_commit=False)
 
-    yield db_session_maker
+    try:
+        yield db_session_maker
+    finally:
+        await engine.dispose()
 
 
 @pytest.fixture
@@ -48,7 +51,10 @@ async def shadow_plugin(db_connection):
 
     shadow_plugin = ShadowPlugin(ctx)
     await shadow_plugin.on_broker_pre_start()
-    yield shadow_plugin
+    try:
+        yield shadow_plugin
+    finally:
+        await shadow_plugin.close()
 
 
 @pytest.mark.asyncio

--- a/tests/mqtt/protocol/test_handler_extended.py
+++ b/tests/mqtt/protocol/test_handler_extended.py
@@ -480,6 +480,20 @@ async def test_reader_loop_stops_when_reader_is_missing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_reader_loop_self_stop_does_not_wait_on_itself() -> None:
+    handler = make_handler(make_session())
+    handler.reader = None
+    handler._reader_ready = asyncio.Event()
+
+    task = asyncio.create_task(handler._reader_loop())
+    handler._reader_task = task
+
+    await asyncio.wait_for(task, timeout=1)
+
+    assert handler._reader_stopped.is_set()
+
+
+@pytest.mark.asyncio
 async def test_reader_loop_handles_reserved_packet_then_eof() -> None:
     session = make_session()
     plugin_manager = DummyPluginManager()

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -27,6 +27,7 @@ class EventTestPlugin(BaseAuthPlugin, BaseTopicPlugin):
         self.test_event_flag = False
 
     async def on_broker_message_received(self) -> None:
+        await asyncio.sleep(0.01)
         self.test_event_flag = True
 
     async def authenticate(self, *, session: Session) -> bool | None:
@@ -73,6 +74,18 @@ class TestPluginManager(unittest.TestCase):
         plugin = manager.get_plugin("EventTestPlugin")
         assert plugin is not None
         assert plugin.test_event_flag
+
+    def test_close_waits_for_fired_events(self) -> None:
+        async def fire_event() -> None:
+            await manager.fire_event(BrokerEvents.MESSAGE_RECEIVED)
+            await manager.close()
+
+        manager = PluginManager("amqtt.test.plugins", context=None)
+        self.loop.run_until_complete(fire_event())
+        plugin = manager.get_plugin("EventTestPlugin")
+        assert plugin is not None
+        assert plugin.test_event_flag
+        assert plugin.test_close_flag
 
     def test_plugin_close_coro(self) -> None:
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -114,6 +114,7 @@ async def test_start_stop(broker, mock_plugin_manager):
         [
             call().fire_event(BrokerEvents.PRE_SHUTDOWN, wait=True),
             call().fire_event(BrokerEvents.POST_SHUTDOWN, wait=True),
+            call().close(),
         ],
         any_order=True,
     )

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1041,6 +1041,17 @@ async def test_broker_broadcast_cancellation(broker):
     await _client_publish(topic, data, qos)
     message = await asyncio.wait_for(sub_client.deliver_message(), timeout=1)
     assert message
+    await sub_client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_broadcast_loop_cancels_pending_delivery_tasks(broker):
+    pending_delivery = asyncio.create_task(asyncio.sleep(60))
+    broker._tasks_queue.append(pending_delivery)
+
+    await asyncio.wait_for(broker._shutdown_broadcast_loop(), timeout=1)
+
+    assert pending_delivery.cancelled()
 
 
 @pytest.mark.asyncio

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -103,8 +103,8 @@ def test_split_bindaddr_port(input_str, output_addr, output_port):
 async def test_start_stop(broker, mock_plugin_manager):
     mock_plugin_manager.assert_has_calls(
         [
-            call().fire_event(BrokerEvents.PRE_START),
-            call().fire_event(BrokerEvents.POST_START),
+            call().fire_event(BrokerEvents.PRE_START, wait=True),
+            call().fire_event(BrokerEvents.POST_START, wait=True),
         ],
         any_order=True,
     )
@@ -112,8 +112,8 @@ async def test_start_stop(broker, mock_plugin_manager):
     await broker.shutdown()
     mock_plugin_manager.assert_has_calls(
         [
-            call().fire_event(BrokerEvents.PRE_SHUTDOWN),
-            call().fire_event(BrokerEvents.POST_SHUTDOWN),
+            call().fire_event(BrokerEvents.PRE_SHUTDOWN, wait=True),
+            call().fire_event(BrokerEvents.POST_SHUTDOWN, wait=True),
         ],
         any_order=True,
     )

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -83,7 +83,6 @@ async def test_broker_taboo():
     assert "Exception" not in stderr.decode("utf-8")
 
 
-@pytest.mark.timeout(25)
 @pytest.mark.asyncio
 async def test_client_keepalive():
 
@@ -95,7 +94,7 @@ async def test_client_keepalive():
     process = subprocess.Popen([sys.executable, keep_alive_script], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     await asyncio.sleep(1)
 
-    stdout, stderr = process.communicate()
+    stdout, stderr = await asyncio.to_thread(process.communicate)
     assert "ERROR" not in stderr.decode("utf-8")
     assert "Exception" not in stderr.decode("utf-8")
 


### PR DESCRIPTION
### Changes included in this PR

broker shutdown didn't properly clean up its and plugin's tasks which caused intermittent failures in test cases, specifically the 'keepalive' timeout test and the 'persistentence' plugins (aiosqlite not getting closed correctly)

### Current behavior

intermittent failures

### New behavior

before the broker pre/post shutsdown, force the event task queue to drain. make sure the plugin manager calls close on all of its plugins to clean up their initialized resources

### Impact

no breaking change. broker shutdown should be more reliable with fewer exceptions on exit.

### Checklist

1. [X] Does your submission pass the existing tests?
2. [X] Are there new tests that cover these additions/changes?
3. [X] Does this PR maintain or increase test coverage?
4. [X] Have you linted your code locally before submission?
