### PR TITLE
deprecation warning cleanup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,8 @@ source = bumper
 
 omit =
     tests/*
+    fuzz/*
+    samples/*
     amqtt/scripts/*.py
 
 [report]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,21 @@ When adding a new feature, please add corollary tests. Pull requests must mainta
 Run `uv run --frozen pytest` locally to see the coverage summary before opening a pull request.
 If you encounter a bug when using aMQTT which you then resolve, please reproduce the issue in a test as well.
 
+### Sample tests
+
+Sample scripts in `samples/` are excluded from coverage scoring, but they still need smoke tests. When adding or updating
+a Python sample, add or update a test in `tests/test_samples.py` and mark the test with the sample script it covers:
+
+```python
+@pytest.mark.sample("client_publish.py")
+async def test_client_publish():
+    ...
+```
+
+The `test_all_sample_files_are_accounted_for` guard checks every `samples/*.py` file against these markers. If a sample is
+intentionally not testable, add it to `IGNORED_SAMPLE_FILES` in `tests/test_samples.py` with a short explanation in the
+pull request.
+
 ### Local fuzzing
 
 The MQTT packet parser has local fuzz coverage using Hypothesis. These tests

--- a/amqtt/contexts.py
+++ b/amqtt/contexts.py
@@ -189,10 +189,12 @@ class BrokerConfig(Dictable):
     def __post_init__(self) -> None:
         """Check config for errors and transform fields for easier use."""
         if self.sys_interval is not None:
-            logger.warning("sys_interval is deprecated, use 'plugins' to define configuration")
+            warnings.warn("sys_interval is deprecated, use 'plugins' to define configuration",
+                          DeprecationWarning, stacklevel=1)
 
         if self.auth is not None or self.topic_check is not None:
-            logger.warning("'auth' and 'topic-check' are deprecated, use 'plugins' to define configuration")
+            warnings.warn("'auth' and 'topic-check' are deprecated, use 'plugins' to define configuration",
+                          DeprecationWarning, stacklevel=1)
 
         default_listener = self.listeners["default"]
         for listener_name, listener in self.listeners.items():
@@ -361,7 +363,9 @@ class ClientConfig(Dictable):
             raise ValueError(msg)
 
         if self.broker is not None:
-            warnings.warn("The 'broker' option is deprecated, please use 'connection' instead.", stacklevel=2)
+            warnings.warn("The 'broker' option is deprecated, please use 'connection' instead. "
+                          "Support for 'broker' will be removed in a future release.",
+                          DeprecationWarning, stacklevel=2)
             self.connection = self.broker
 
         if bool(not self.connection.keyfile) ^ bool(not self.connection.certfile):

--- a/amqtt/contrib/persistence.py
+++ b/amqtt/contrib/persistence.py
@@ -85,8 +85,8 @@ class SessionDBPlugin(BasePlugin[BrokerContext]):
         if configured_file:
             connection = f"sqlite+aiosqlite:///{configured_file}"
             warnings.warn(
-                "persistence plugin: `file` option is now deprecated, use full `connection` string instead."
-                " existing configurations will continue to work.",
+                "persistence plugin: `file` option is now deprecated, use full `connection` string instead. "
+                " Support for `file` will be removed in future versions.",
                 DeprecationWarning,
                 stacklevel=0
             )
@@ -294,7 +294,7 @@ class SessionDBPlugin(BasePlugin[BrokerContext]):
         """
         file: str | Path | None = None
         """path & filename to store the sqlite session db
-        Deprecated in 0.11.4, use `connection` instead.
+        Deprecated: use `connection` instead.
         Existing configurations will continue to work.
         """
 

--- a/amqtt/plugins/manager.py
+++ b/amqtt/plugins/manager.py
@@ -79,9 +79,9 @@ class PluginManager(Generic[C]):
         self._load_plugins(namespace)
 
         if self.get_plugin("BrokerSysPlugin"):
-            warnings.warn("The underlying library for the `BrokerSysPlugin` will be removed in future versions. "
-                          "Please explicitly update your environment to depend on 'amqtt[dollarsys]'"
-                          " to ensure compatibility.", DeprecationWarning, stacklevel=4)
+            warnings.warn("`BrokerSysPlugin`: `psutil` will be removed as a project-level dependency in future versions. "
+                          "Please explicitly update your environment to use the optional dependency "
+                          "to ensure compatibility: 'amqtt[dollarsys]'", DeprecationWarning, stacklevel=4)
 
         self._fired_events: list[asyncio.Future[Any]] = []
         plugins_manager[namespace] = self
@@ -105,9 +105,11 @@ class PluginManager(Generic[C]):
             # plugins loaded directly from config dictionary
 
             if "auth" in self.app_context.config and self.app_context.config["auth"] is not None:
-                self.logger.warning("Loading plugins from config will ignore 'auth' section of config")
+                warnings.warn("Loading plugins from config will ignore 'auth' section of config.",
+                              DeprecationWarning, stacklevel=1)
             if "topic-check" in self.app_context.config and self.app_context.config["topic-check"] is not None:
-                self.logger.warning("Loading plugins from config will ignore 'topic-check' section of config")
+                warnings.warn("Loading plugins from config will ignore 'topic-check' section of config.",
+                              DeprecationWarning, stacklevel=1)
 
             plugins_config: list[Any] | dict[str, Any] = self.app_context.config.get("plugins", [])
 

--- a/amqtt/plugins/topic_checking.py
+++ b/amqtt/plugins/topic_checking.py
@@ -30,7 +30,9 @@ class TopicAccessControlListPlugin(BaseTopicPlugin):
         super().__init__(context)
 
         if self._get_config_option("acl", None):
-            warnings.warn("The 'acl' option is deprecated, please use 'subscribe-acl' instead.", stacklevel=1)
+            warnings.warn("The 'acl' option is deprecated, please use 'subscribe-acl' instead. "
+                          "Support will dropped in future versions.",
+                          DeprecationWarning, stacklevel=1)
 
         if self._get_config_option("acl", None) and self._get_config_option("subscribe-acl", None):
             msg = "'acl' has been replaced with 'subscribe-acl'; only one may be included"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,6 +252,7 @@ timeout = 15
 asyncio_default_fixture_loop_scope = "function"
 markers = [
   "extended: interoperability tests that require non-Python runtimes or external client dependencies",
+  "sample(name): sample script covered by a sample smoke test",
 ]
 #addopts = ["--tb=short", "--capture=tee-sys"]
 #log_cli = true

--- a/tests/test_broker_config.py
+++ b/tests/test_broker_config.py
@@ -154,7 +154,7 @@ def test_client_config_rejects_invalid_default_qos() -> None:
 def test_client_config_uses_deprecated_broker_config() -> None:
     broker_connection = ConnectionConfig(uri="mqtt://broker.example:1883")
 
-    with pytest.warns(UserWarning, match="broker"):
+    with pytest.warns(DeprecationWarning, match="broker"):
         client_config = ClientConfig(broker=broker_connection)
 
     assert client_config.connection is broker_connection

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -1,3 +1,4 @@
+import ast
 import asyncio
 import logging
 import multiprocessing
@@ -23,7 +24,53 @@ from samples.broker_dollar_topics import config as broker_dollar_topics_config
 
 logger = logging.getLogger(__name__)
 
+SAMPLES_DIR = Path(__file__).parent.parent / "samples"
+IGNORED_SAMPLE_FILES = frozenset()
+
+
+def _is_sample_marker(decorator: ast.expr) -> bool:
+    return (
+        isinstance(decorator, ast.Call)
+        and isinstance(decorator.func, ast.Attribute)
+        and decorator.func.attr == "sample"
+        and isinstance(decorator.func.value, ast.Attribute)
+        and decorator.func.value.attr == "mark"
+        and isinstance(decorator.func.value.value, ast.Name)
+        and decorator.func.value.value.id == "pytest"
+    )
+
+
+def _sample_marker_files() -> set[str]:
+    tree = ast.parse(Path(__file__).read_text())
+    sample_files = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for decorator in node.decorator_list:
+                if _is_sample_marker(decorator):
+                    sample_files.update(
+                        arg.value
+                        for arg in decorator.args
+                        if isinstance(arg, ast.Constant) and isinstance(arg.value, str)
+                    )
+
+    return sample_files
+
+
+def test_all_sample_files_are_accounted_for():
+    sample_files = {path.name for path in SAMPLES_DIR.glob("*.py")}
+    marked_sample_files = _sample_marker_files()
+    missing_tests = sorted(sample_files - marked_sample_files - IGNORED_SAMPLE_FILES)
+    stale_markers = sorted(marked_sample_files - sample_files)
+    stale_ignored = sorted(IGNORED_SAMPLE_FILES - sample_files)
+
+    assert not missing_tests, f"Add @pytest.mark.sample(...) coverage for new sample files: {missing_tests}"
+    assert not stale_markers, f"Remove stale sample markers: {stale_markers}"
+    assert not stale_ignored, f"Remove stale ignored sample entries: {stale_ignored}"
+
+
 @pytest.mark.asyncio
+@pytest.mark.sample("broker_acl.py")
 async def test_broker_acl():
     broker_acl_script = Path(__file__).parent.parent / "samples/broker_acl.py"
     process = subprocess.Popen([sys.executable, broker_acl_script], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -38,6 +85,22 @@ async def test_broker_acl():
 
 
 @pytest.mark.asyncio
+@pytest.mark.sample("broker_custom_plugin.py")
+async def test_broker_custom_plugin():
+    broker_custom_plugin_script = SAMPLES_DIR / "broker_custom_plugin.py"
+    process = subprocess.Popen([sys.executable, broker_custom_plugin_script], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    await asyncio.sleep(2)
+
+    process.send_signal(signal.SIGINT)
+    stdout, stderr = process.communicate()
+    logger.debug(stderr.decode("utf-8"))
+    assert "Broker closed" in stderr.decode("utf-8")
+    assert "ERROR" not in stderr.decode("utf-8")
+    assert "Exception" not in stderr.decode("utf-8")
+
+
+@pytest.mark.asyncio
+@pytest.mark.sample("broker_simple.py")
 async def test_broker_simple():
     broker_simple_script = Path(__file__).parent.parent / "samples/broker_simple.py"
     process = subprocess.Popen([sys.executable, broker_simple_script], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -54,6 +117,7 @@ async def test_broker_simple():
 
 
 @pytest.mark.asyncio
+@pytest.mark.sample("broker_start.py")
 async def test_broker_start():
     broker_start_script = Path(__file__).parent.parent / "samples/broker_start.py"
     process = subprocess.Popen([sys.executable, broker_start_script], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -69,6 +133,7 @@ async def test_broker_start():
 
 
 @pytest.mark.asyncio
+@pytest.mark.sample("broker_taboo.py")
 async def test_broker_taboo():
     broker_taboo_script = Path(__file__).parent.parent / "samples/broker_taboo.py"
     process = subprocess.Popen([sys.executable, broker_taboo_script], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -84,6 +149,7 @@ async def test_broker_taboo():
 
 
 @pytest.mark.asyncio
+@pytest.mark.sample("client_keepalive.py")
 async def test_client_keepalive():
 
     broker = Broker()
@@ -102,6 +168,7 @@ async def test_client_keepalive():
 
 
 @pytest.mark.asyncio
+@pytest.mark.sample("client_publish.py")
 async def test_client_publish():
     broker = Broker()
     await broker.start()
@@ -138,6 +205,7 @@ def broker_ssl_config(rsa_keys):
     }
 
 @pytest.mark.asyncio
+@pytest.mark.sample("client_publish_ssl.py")
 async def test_client_publish_ssl(broker_ssl_config, rsa_keys):
     certfile, _ = rsa_keys
     # generate a self-signed certificate for this test
@@ -159,6 +227,7 @@ async def test_client_publish_ssl(broker_ssl_config, rsa_keys):
 
 
 @pytest.mark.asyncio
+@pytest.mark.sample("client_publish_acl.py")
 async def test_client_publish_acl():
 
     broker = Broker()
@@ -191,6 +260,7 @@ broker_ws_config = {
 }
 
 @pytest.mark.asyncio
+@pytest.mark.sample("client_publish_ws.py")
 async def test_client_publish_ws():
     # start a secure broker
     broker = Broker(config=broker_ws_config)
@@ -225,6 +295,7 @@ broker_std_config = {
 
 
 @pytest.mark.asyncio
+@pytest.mark.sample("client_subscribe.py")
 async def test_client_subscribe():
 
     # start a standard broker
@@ -253,6 +324,7 @@ async def test_client_subscribe():
 
 
 @pytest.mark.asyncio
+@pytest.mark.sample("client_subscribe_acl.py")
 async def test_client_subscribe_plugin_acl():
     broker = Broker(config=broker_acl_config)
     await broker.start()
@@ -272,6 +344,7 @@ async def test_client_subscribe_plugin_acl():
 
 
 @pytest.mark.asyncio
+@pytest.mark.sample("client_subscribe_acl.py")
 async def test_client_subscribe_plugin_taboo():
     broker = Broker(config=broker_taboo_config)
     await broker.start()
@@ -319,6 +392,7 @@ async def _wait_for_port(host: str, port: int, timeout: float = 15.0) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.sample("http_server_integration.py")
 async def test_external_http_server(external_http_server):
 
     await _wait_for_port("127.0.0.1", 8080)
@@ -332,6 +406,7 @@ async def test_external_http_server(external_http_server):
 
 
 @pytest.mark.asyncio
+@pytest.mark.sample("unix_sockets.py")
 async def test_unix_connection():
 
     unix_socket_script = Path(__file__).parent.parent / "samples/unix_sockets.py"
@@ -360,6 +435,7 @@ async def test_unix_connection():
 
 
 @pytest.mark.asyncio
+@pytest.mark.sample("broker_dollar_topics.py")
 async def test_allowable_dollar_topics():
 
     broker = Broker(config=broker_dollar_topics_config)


### PR DESCRIPTION
### Changes included in this PR

- clarify deprecation warning messages. consistent use of `DeprecationWarning`
- exclude `samples` and `fuzz` from coverage report; include check to make sure `samples` have at least one test

### Impact

no impact. no change in behavior.

### Checklist

1. [X] Does your submission pass the existing tests?
2. [X] Are there new tests that cover these additions/changes?
3. [X] Does this PR maintain or increase test coverage?
4. [X] Have you linted your code locally before submission?
