### PR TITLE
performance: timeout task create/cancels

### DIFF
--- a/amqtt/mqtt/protocol/broker_handler.py
+++ b/amqtt/mqtt/protocol/broker_handler.py
@@ -84,7 +84,9 @@ class BrokerProtocolHandler(ProtocolHandler["BrokerContext"]):
         pass
 
     def handle_read_timeout(self) -> None:
-        pass
+        if self._disconnect_waiter and not self._disconnect_waiter.done():
+            self.logger.debug("Client keep-alive timeout, closing connection")
+            self._disconnect_waiter.set_result(None)
 
     async def handle_disconnect(self, disconnect: DisconnectPacket | None) -> None:
         """Handle a disconnect packet and notify the disconnect waiter."""

--- a/amqtt/mqtt/protocol/handler.py
+++ b/amqtt/mqtt/protocol/handler.py
@@ -84,7 +84,7 @@ class ProtocolHandler(Generic[C]):
             asyncio.set_event_loop(self._loop)
 
         self._reader_task: asyncio.Task[None] | None = None
-        self._keepalive_task: asyncio.TimerHandle | None = None
+        self._keepalive_watcher: asyncio.Task[None] | None = None
         self._reader_ready: asyncio.Event | None = None
         self._reader_stopped = asyncio.Event()
         self._puback_waiters: dict[int, asyncio.Future[PubackPacket]] = {}
@@ -120,6 +120,14 @@ class ProtocolHandler(Generic[C]):
     def _is_attached(self) -> bool:
         return bool(self.session)
 
+    async def timeout_watcher(self) -> None:
+        while self._is_attached() and self.keepalive_timeout is not None:
+            await asyncio.sleep(self.keepalive_timeout)
+            if self.session is None:
+                break
+            if self.session.last_write_at + self.keepalive_timeout <= self._loop.time():
+                self.handle_write_timeout()
+
     async def start(self) -> None:
         if not self._is_attached():
             msg = "Handler is not attached to a stream"
@@ -129,7 +137,11 @@ class ProtocolHandler(Generic[C]):
         self._reader_task = asyncio.create_task(self._reader_loop())
         await self._reader_ready.wait()
         if self._loop is not None and self.keepalive_timeout is not None:
-            self._keepalive_task = self._loop.call_later(self.keepalive_timeout, self.handle_write_timeout)
+            if self.session is None:
+                msg = "Session is not initialized."
+                raise AMQTTError(msg)
+            self.session.last_write_at = self._loop.time()
+            self._keepalive_watcher = self._loop.create_task(self.timeout_watcher())
         self.logger.debug("Handler tasks started")
         await self._retry_deliveries()
         self.logger.debug("Handler ready")
@@ -137,8 +149,8 @@ class ProtocolHandler(Generic[C]):
     async def stop(self) -> None:
         # Stop messages flow waiter
         self._stop_waiters()
-        if self._keepalive_task:
-            self._keepalive_task.cancel()
+        if self._keepalive_watcher:
+            self._keepalive_watcher.cancel()
         self.logger.debug("Waiting for tasks to be stopped")
         if self._reader_task and self._reader_task is not asyncio.current_task() and not self._reader_task.done():
             self._reader_task.cancel()
@@ -562,10 +574,8 @@ class ProtocolHandler(Generic[C]):
             if self.writer:
                 async with self._write_lock:
                     await packet.to_stream(self.writer)
-            if self._keepalive_task:
-                self._keepalive_task.cancel()
-                if self.keepalive_timeout is not None:
-                    self._keepalive_task = self._loop.call_later(self.keepalive_timeout, self.handle_write_timeout)
+            if self._keepalive_watcher and self.session is not None:
+                self.session.last_write_at = self._loop.time()
             await self.plugins_manager.fire_event(MQTTEvents.PACKET_SENT, packet=packet, session=self.session)
         except (ConnectionResetError, BrokenPipeError):
             await self.handle_connection_closed()

--- a/amqtt/session.py
+++ b/amqtt/session.py
@@ -154,6 +154,7 @@ class Session:
         self._packet_id: int = 0
         self.parent: int = 0
         self.last_connect_time: int | None = None
+        self.last_write_at: float = 0.0
         self.ssl_object: ssl.SSLObject | None = None
         self.last_disconnect_time: int | None = None
         self.attributes: dict[str, Any] = {}

--- a/tests/mqtt/protocol/test_handler.py
+++ b/tests/mqtt/protocol/test_handler.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import suppress
 import logging
 import secrets
 from typing import Any
@@ -26,6 +27,39 @@ def rand_packet_id():
 
 def adapt(reader, writer):
     return StreamReaderAdapter(reader), StreamWriterAdapter(writer)
+
+
+class BlockingReader:
+    def __init__(self):
+        self._waiter = asyncio.Future()
+
+    async def read(self, n=-1):
+        return await self._waiter
+
+    def feed_eof(self):
+        self._waiter.cancel()
+
+
+class BufferWriter:
+    def __init__(self):
+        self.data = bytearray()
+        self.drained = False
+        self.closed = False
+
+    def write(self, data):
+        self.data.extend(data)
+
+    async def drain(self):
+        self.drained = True
+
+    def get_peer_info(self):
+        return "127.0.0.1", 0
+
+    def get_ssl_info(self):
+        return None
+
+    async def close(self):
+        self.closed = True
 
 
 class ProtocolHandlerTest(unittest.TestCase):
@@ -83,6 +117,55 @@ class ProtocolHandlerTest(unittest.TestCase):
         exception = future.exception()
         if exception:
             raise exception
+
+    def test_start_enables_keepalive_watcher(self):
+        async def test_coro() -> None:
+            session = Session()
+            session.keep_alive = 30
+            handler = ProtocolHandler(self.plugin_manager)
+            handler.attach(session, BlockingReader(), BufferWriter())
+
+            before_start = self.loop.time()
+            await handler.start()
+            after_start = self.loop.time()
+
+            try:
+                assert handler._keepalive_watcher is not None
+                assert not handler._keepalive_watcher.done()
+                assert before_start <= session.last_write_at <= after_start
+            finally:
+                await self.stop_handler(handler, session)
+                await asyncio.sleep(0)
+                assert handler._keepalive_watcher is not None
+                assert handler._keepalive_watcher.cancelled()
+
+        self.loop.run_until_complete(test_coro())
+
+    def test_send_packet_refreshes_keepalive_timestamp(self):
+        async def test_coro() -> None:
+            session = Session()
+            session.keep_alive = 30
+            session.last_write_at = 0.0
+            writer = BufferWriter()
+            handler = ProtocolHandler(self.plugin_manager, session=session, loop=self.loop)
+            handler.writer = writer
+            handler._keepalive_watcher = asyncio.create_task(asyncio.sleep(60))
+
+            try:
+                packet = PublishPacket.build("/topic", b"test_data", None, False, QOS_0, False)
+                before_send = self.loop.time()
+                await handler._send_packet(packet)
+                after_send = self.loop.time()
+
+                assert writer.data
+                assert writer.drained
+                assert before_send <= session.last_write_at <= after_send
+            finally:
+                handler._keepalive_watcher.cancel()
+                with suppress(asyncio.CancelledError):
+                    await handler._keepalive_watcher
+
+        self.loop.run_until_complete(test_coro())
 
     def test_publish_qos0(self):
         async def server_mock(reader, writer) -> None:

--- a/tests/mqtt/protocol/test_handler_extended.py
+++ b/tests/mqtt/protocol/test_handler_extended.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 import logging
 from typing import Any
 
@@ -415,19 +416,24 @@ async def test_puback_handler_requires_variable_header() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_packet_resets_keepalive_timer_and_fires_event() -> None:
+async def test_send_packet_refreshes_keepalive_timestamp_and_fires_event() -> None:
     session = make_session()
     session.keep_alive = 10
+    session.last_write_at = 0.0
     handler = make_handler(session)
-    previous_timer = asyncio.get_running_loop().call_later(60, lambda: None)
-    handler._keepalive_task = previous_timer
+    handler._keepalive_watcher = asyncio.create_task(asyncio.sleep(60))
 
-    await handler._send_packet(PingReqPacket())
+    try:
+        before_send = handler._loop.time()
+        await handler._send_packet(PingReqPacket())
+        after_send = handler._loop.time()
 
-    assert previous_timer.cancelled()
-    assert handler._keepalive_task is not previous_timer
-    assert handler.plugins_manager.events[-1][0] == (MQTTEvents.PACKET_SENT,)
-    handler._keepalive_task.cancel()
+        assert before_send <= session.last_write_at <= after_send
+        assert handler.plugins_manager.events[-1][0] == (MQTTEvents.PACKET_SENT,)
+    finally:
+        handler._keepalive_watcher.cancel()
+        with suppress(asyncio.CancelledError):
+            await handler._keepalive_watcher
 
 
 @pytest.mark.asyncio

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -143,6 +143,31 @@ async def test_client_connect(broker, mock_plugin_manager):
 
 
 @pytest.mark.asyncio
+async def test_client_keep_alive_timeout_closes_connection(broker):
+    conn_reader, conn_writer = await asyncio.open_connection("127.0.0.1", 1883)
+    reader = StreamReaderAdapter(conn_reader)
+    writer = StreamWriterAdapter(conn_writer)
+
+    vh = ConnectVariableHeader()
+    payload = ConnectPayload()
+    vh.keep_alive = 1
+    vh.clean_session_flag = True
+    payload.client_id = "keep-alive-timeout-client"
+    connect = ConnectPacket(variable_header=vh, payload=payload)
+
+    await connect.to_stream(writer)
+    connack = await ConnackPacket.from_stream(reader)
+    assert connack.return_code == 0
+    assert payload.client_id in broker._sessions
+
+    try:
+        assert await asyncio.wait_for(conn_reader.read(1), timeout=3) == b""
+    finally:
+        conn_writer.close()
+        await conn_writer.wait_closed()
+
+
+@pytest.mark.asyncio
 async def _connect_tcp(broker):
     process = psutil.Process()
     connections_number = 10


### PR DESCRIPTION

### Changes included in this PR

previously, 'keepalive' timeout was tracked by using 'call_later' to create a task, cancel it and then schedule a new task. instead, use a single task which checks time since last write

### Impact

No behavior change. Improves performance by not having to create/cancel tasks on every packet write.

### Checklist

1. [X] Does your submission pass the existing tests?
2. [X] Are there new tests that cover these additions/changes?
3. [X] Does this PR maintain or increase test coverage?
4. [X] Have you linted your code locally before submission?
