### PR TITLE
configurable mTLS client certificate policy and CRL support

### DIFF
--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -21,7 +21,15 @@ from amqtt.adapters import (
     WebSocketsWriter,
     WriterAdapter,
 )
-from amqtt.contexts import Action, BaseContext, BrokerConfig, ListenerConfig, ListenerType
+from amqtt.contexts import (
+    Action,
+    BaseContext,
+    BrokerConfig,
+    ListenerConfig,
+    ListenerType,
+    ListenerVerifyFlags,
+    ListenerVerifyMode,
+)
 from amqtt.errors import AMQTTError, BrokerError, MQTTError, NoDataError
 from amqtt.mqtt.protocol.broker_handler import BrokerProtocolHandler
 from amqtt.session import ApplicationMessage, OutgoingApplicationMessage, Session
@@ -38,6 +46,16 @@ _BROADCAST: TypeAlias = dict[str, Session | str | bytes | bytearray | int | None
 DEFAULT_PORTS = {"tcp": 1883, "ws": 8883}
 AMQTT_MAGIC_VALUE_RET_SUBSCRIBED = 0x80
 _BROADCAST_SHUTDOWN_TIMEOUT = 5
+_CLIENT_CERT_VERIFY_MODE = {
+    ListenerVerifyMode.NONE: ssl.CERT_NONE,
+    ListenerVerifyMode.OPTIONAL: ssl.CERT_OPTIONAL,
+    ListenerVerifyMode.REQUIRED: ssl.CERT_REQUIRED,
+}
+_CRL_VERIFY_FLAGS = {
+    ListenerVerifyFlags.NONE: ssl.VerifyFlags(0),
+    ListenerVerifyFlags.LEAF: ssl.VERIFY_CRL_CHECK_LEAF,
+    ListenerVerifyFlags.CHAIN: ssl.VERIFY_CRL_CHECK_CHAIN,
+}
 
 
 class RetainedApplicationMessage(ApplicationMessage):
@@ -314,7 +332,10 @@ class Broker:
                 cadata=listener.get("cadata"),
             )
             ssl_context.load_cert_chain(listener["certfile"], listener["keyfile"])
-            ssl_context.verify_mode = ssl.CERT_OPTIONAL
+            ssl_context.verify_mode = _CLIENT_CERT_VERIFY_MODE[listener.client_cert]
+            if listener.crlfile or listener.crlpath:
+                ssl_context.load_verify_locations(cafile=listener.crlfile, capath=listener.crlpath)
+            ssl_context.verify_flags |= _CRL_VERIFY_FLAGS[listener.crl_check]
         except KeyError as ke:
             msg = f"'certfile' or 'keyfile' configuration parameter missing: {ke}"
             raise BrokerError(msg) from ke

--- a/amqtt/contexts.py
+++ b/amqtt/contexts.py
@@ -52,6 +52,22 @@ class ListenerType(StrEnum):
         return f'"{self.value!s}"'
 
 
+class ListenerVerifyMode(StrEnum):
+    """TLS listener client certificate verify mode."""
+
+    NONE = "none"
+    OPTIONAL = "optional"
+    REQUIRED = "required"
+
+
+class ListenerVerifyFlags(StrEnum):
+    """TLS listener certificate revocation verify flags."""
+
+    NONE = "none"
+    LEAF = "leaf"
+    CHAIN = "chain"
+
+
 class Dictable:
     """Add dictionary methods to a dataclass."""
 
@@ -117,6 +133,14 @@ class ListenerConfig(Dictable):
     certificates needed to establish the certificate's authenticity.)"""
     keyfile: str | Path | None = None
     """Full path to file in PEM format containing the server's private key."""
+    client_cert: ListenerVerifyMode = ListenerVerifyMode.OPTIONAL
+    """Client certificate policy for TLS listeners: `none`, `optional`, or `required`."""
+    crlfile: str | Path | None = None
+    """Path to a file containing certificate revocation list material in PEM format."""
+    crlpath: str | Path | None = None
+    """Path to a directory containing certificate revocation list material."""
+    crl_check: ListenerVerifyFlags = ListenerVerifyFlags.NONE
+    """Certificate revocation check policy for TLS listeners: `none`, `leaf`, or `chain`."""
     reader: str | None = None
     writer: str | None = None
 
@@ -126,7 +150,7 @@ class ListenerConfig(Dictable):
             msg = "If specifying the 'certfile' or 'keyfile', both are required."
             raise ValueError(msg)
 
-        for fn in ("cafile", "capath", "certfile", "keyfile"):
+        for fn in ("cafile", "capath", "certfile", "keyfile", "crlfile", "crlpath"):
             if isinstance(getattr(self, fn), str):
                 setattr(self, fn, Path(getattr(self, fn)))
             if getattr(self, fn) and not getattr(self, fn).exists():
@@ -230,7 +254,7 @@ class BrokerConfig(Dictable):
         return dict_to_dataclass(data_class=BrokerConfig,
                                  data=d,
                                  config=DaciteConfig(
-                                     cast=[StrEnum, ListenerType],
+                                     cast=[StrEnum, ListenerType, ListenerVerifyMode, ListenerVerifyFlags],
                                      strict=True,
                                      type_hooks={list[dict[str, Any]]: cls._coerce_lists}
                                  ))

--- a/docs/plugins/cert.md
+++ b/docs/plugins/cert.md
@@ -32,6 +32,7 @@ listeners:
     certfile: server.crt
     keyfile: server.key
     cafile: ca.crt
+    client_cert: required
 plugins:
   amqtt.contrib.cert.CertificateAuthPlugin:
     uri_domain: my.domain.name
@@ -89,6 +90,12 @@ and `device_creds`.
 !!! note "Configuring broker & client for using Self-signed root CA"
     If using self-signed root credentials, the `cafile` configuration for both broker and client need to be
     configured with `cafile` set to the `ca.crt`.
+
+!!! note "Client certificate policy and revocation checks"
+    TLS listeners default to `client_cert: optional`, which preserves existing behavior. Set
+    `client_cert: required` to require clients to provide certificates during the TLS handshake.
+    To enforce certificate revocation lists, configure `crlfile` or `crlpath` and set
+    `crl_check` to `leaf` or `chain`.
 
 ## Root & Certificate Credentials
 

--- a/docs/references/broker_config.md
+++ b/docs/references/broker_config.md
@@ -113,6 +113,9 @@ listeners:
         capath: 'certificate data'
         certfile: /some/certfile
         keyfile: /some/keyfile
+        client_cert: required
+        crlfile: /some/crlfile
+        crl_check: leaf
     my-ws-1:
         bind: 0.0.0.0:8080
         type: ws

--- a/tests/contrib/test_cert.py
+++ b/tests/contrib/test_cert.py
@@ -124,6 +124,7 @@ async def test_client_broker_cert_authentication(ca_creds, server_creds, device_
                 'keyfile': server_key,
                 'certfile': server_crt,
                 'cafile': ca_crt,
+                'client_cert': 'required',
             }
         },
         'plugins': {
@@ -138,7 +139,7 @@ async def test_client_broker_cert_authentication(ca_creds, server_creds, device_
 
     client_config = {
         'auto_reconnect': False,
-        'broker': {
+        'connection': {
             'cafile': ca_crt,
             'certfile': device_crt,
             'keyfile': device_key
@@ -157,6 +158,47 @@ async def test_client_broker_cert_authentication(ca_creds, server_creds, device_
     await c.disconnect()
     await asyncio.sleep(0.1)
     await b.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_client_cert_required_rejects_client_without_certificate(ca_creds, server_creds):
+    _, ca_crt = ca_creds
+    server_key, server_crt = server_creds
+    broker_config = {
+        'listeners': {
+            'default': {
+                'type':'tcp',
+                'bind':'127.0.0.1:0',
+                'ssl': True,
+                'keyfile': server_key,
+                'certfile': server_crt,
+                'cafile': ca_crt,
+                'client_cert': 'required',
+            }
+        },
+        'plugins': {
+            'amqtt.plugins.authentication.AnonymousAuthPlugin': {'allow_anonymous': True},
+        }
+    }
+
+    b = Broker(config=broker_config)
+    await b.start()
+    server_socket = b._servers['default'].instance.sockets[0]
+    port = server_socket.getsockname()[1]
+
+    client_config = {
+        'auto_reconnect': False,
+        'connection': {
+            'cafile': ca_crt,
+        }
+    }
+
+    c = MQTTClient(config=client_config, client_id='mydeviceid')
+    try:
+        with pytest.raises(ConnectError):
+            await c.connect(f'mqtts://127.0.0.1:{port}')
+    finally:
+        await b.shutdown()
 
 
 def ssl_error_logger(loop, context):

--- a/tests/test_broker_config.py
+++ b/tests/test_broker_config.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+import ssl
 from typing import Any
 
 import pytest
@@ -14,7 +15,18 @@ except ImportError:
 
 from dacite import from_dict, Config
 
-from amqtt.contexts import BrokerConfig, ClientConfig, ConnectionConfig, ListenerConfig, ListenerType, TopicConfig, WillConfig
+from amqtt.broker import Broker
+from amqtt.contexts import (
+    BrokerConfig,
+    ClientConfig,
+    ConnectionConfig,
+    ListenerConfig,
+    ListenerType,
+    ListenerVerifyFlags,
+    ListenerVerifyMode,
+    TopicConfig,
+    WillConfig,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +78,24 @@ def test_broker_config_from_dict_normalizes_topic_check_and_plugin_lists() -> No
     }
 
 
+def test_broker_config_from_dict_casts_listener_tls_policy_enums() -> None:
+    broker_config = BrokerConfig.from_dict(
+        {
+            "listeners": {
+                "default": {
+                    "bind": "127.0.0.1:8883",
+                    "client_cert": "required",
+                    "crl_check": "leaf",
+                },
+            },
+        },
+    )
+
+    listener_config = broker_config.listeners["default"]
+    assert listener_config.client_cert is ListenerVerifyMode.REQUIRED
+    assert listener_config.crl_check is ListenerVerifyFlags.LEAF
+
+
 def test_listener_config_requires_certfile_and_keyfile_together(tmp_path: Path) -> None:
     certfile = tmp_path / "cert.pem"
     certfile.write_text("cert", encoding="utf-8")
@@ -98,12 +128,97 @@ def test_listener_config_converts_existing_file_fields_to_paths(tmp_path: Path) 
     assert listener_config.keyfile == keyfile
 
 
+def test_listener_config_converts_existing_crl_fields_to_paths(tmp_path: Path) -> None:
+    crlfile = tmp_path / "ca.crl"
+    crlpath = tmp_path / "crls"
+    crlfile.write_text("placeholder", encoding="utf-8")
+    crlpath.mkdir()
+
+    listener_config = ListenerConfig(crlfile=str(crlfile), crlpath=str(crlpath))
+
+    assert listener_config.crlfile == crlfile
+    assert listener_config.crlpath == crlpath
+
+
 def test_listener_config_rejects_missing_file_fields(tmp_path: Path) -> None:
     keyfile = tmp_path / "key.pem"
     keyfile.write_text("key", encoding="utf-8")
 
     with pytest.raises(FileNotFoundError, match="certfile"):
         ListenerConfig(certfile=tmp_path / "missing-cert.pem", keyfile=keyfile)
+
+
+def test_listener_config_rejects_missing_crl_fields(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="crlfile"):
+        ListenerConfig(crlfile=tmp_path / "missing-ca.crl")
+
+    with pytest.raises(FileNotFoundError, match="crlpath"):
+        ListenerConfig(crlpath=tmp_path / "missing-crl-dir")
+
+
+def test_broker_config_from_dict_fails_client_cert_option() -> None:
+    with pytest.raises(ValueError, match="incorrect"):
+        _ = BrokerConfig.from_dict(
+            {
+                "listeners": {
+                    "default": {
+                        "bind": "127.0.0.1:8883",
+                        "client_cert": "incorrect",
+                    },
+                },
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    ("client_cert", "verify_mode"),
+    [
+        ("none", ssl.CERT_NONE),
+        ("optional", ssl.CERT_OPTIONAL),
+        ("required", ssl.CERT_REQUIRED),
+    ],
+)
+def test_broker_ssl_context_applies_client_cert_policy(
+    rsa_keys: tuple[Path, Path],
+    client_cert: str,
+    verify_mode: ssl.VerifyMode,
+) -> None:
+    certfile, keyfile = rsa_keys
+    listener = ListenerConfig(ssl=True, certfile=certfile, keyfile=keyfile, client_cert=client_cert)
+
+    ssl_context = Broker._create_ssl_context(listener)
+
+    assert ssl_context.verify_mode == verify_mode
+
+
+@pytest.mark.parametrize(
+    ("crl_check", "verify_flag"),
+    [
+        ("leaf", ssl.VERIFY_CRL_CHECK_LEAF),
+        ("chain", ssl.VERIFY_CRL_CHECK_CHAIN),
+    ],
+)
+def test_broker_ssl_context_applies_crl_verify_flags(
+    rsa_keys: tuple[Path, Path],
+    crl_check: str,
+    verify_flag: ssl.VerifyFlags,
+) -> None:
+    certfile, keyfile = rsa_keys
+    listener = ListenerConfig(ssl=True, certfile=certfile, keyfile=keyfile, crl_check=crl_check)
+
+    ssl_context = Broker._create_ssl_context(listener)
+
+    assert ssl_context.verify_flags & verify_flag
+
+
+def test_broker_ssl_context_default_crl_check_does_not_enable_crl_flags(rsa_keys: tuple[Path, Path]) -> None:
+    certfile, keyfile = rsa_keys
+    listener = ListenerConfig(ssl=True, certfile=certfile, keyfile=keyfile)
+
+    ssl_context = Broker._create_ssl_context(listener)
+
+    assert not ssl_context.verify_flags & ssl.VERIFY_CRL_CHECK_LEAF
+    assert not ssl_context.verify_flags & ssl.VERIFY_CRL_CHECK_CHAIN
 
 
 def test_connection_config_requires_certfile_and_keyfile_together() -> None:


### PR DESCRIPTION
### Changes included in this PR

Add listener-level configuration for server-side mTLS client certificate policy and certificate revocation list checks.

### New behavior

Additional configuration parameters:

```
    client_cert: ListenerVerifyMode = ListenerVerifyMode.OPTIONAL
    """Client certificate policy for TLS listeners: `none`, `optional`, or `required`."""
    crlfile: str | Path | None = None
    """Path to a file containing certificate revocation list material in PEM format."""
    crlpath: str | Path | None = None
    """Path to a directory containing certificate revocation list material."""
    crl_check: ListenerVerifyFlags = ListenerVerifyFlags.NONE
    """Certificate revocation check policy for TLS listeners: `none`, `leaf`, or `chain`."""
```

With these enumerations:

```
class ListenerVerifyMode(StrEnum):
    """TLS listener client certificate verify mode."""

    NONE = "none"
    OPTIONAL = "optional"
    REQUIRED = "required"


class ListenerVerifyFlags(StrEnum):
    """TLS listener certificate revocation verify flags."""

    NONE = "none"
    LEAF = "leaf"
    CHAIN = "chain"
```

### Impact

no breaking changes. additional functionality only.

### Checklist

1. [X] Does your submission pass the existing tests?
2. [X] Are there new tests that cover these additions/changes?
3. [X] Does this PR maintain or increase test coverage?
4. [X] Have you linted your code locally before submission?
