### PR TITLE
adding config to SYS plugin enabling setting of QoS

### DIFF
--- a/amqtt/plugins/sys/broker.py
+++ b/amqtt/plugins/sys/broker.py
@@ -248,7 +248,7 @@ class BrokerSysPlugin(BasePlugin[BrokerContext]):
         qos: int | None = None
         """QoS level for system topic updates. Blank to inherit subscriber QoS. Otherwise: 0, 1 or 2 only."""
 
-        def __post_init__(self):
+        def __post_init__(self) -> None:
             if self.qos is not None and (self.qos < 0 or self.qos > 2):
                 msg = "QoS level must be 0, 1 or 2."
                 raise PluginInitError(f"BrokerSysPlugin: {msg}")

--- a/amqtt/plugins/sys/broker.py
+++ b/amqtt/plugins/sys/broker.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, SupportsIndex, SupportsInt, TypeAlias  # pylint: disable=C0412
 
 import psutil
+from amqtt.errors import PluginInitError
 
 from amqtt.plugins.base import BasePlugin
 from amqtt.session import Session
@@ -73,6 +74,7 @@ class BrokerSysPlugin(BasePlugin[BrokerContext]):
         self._sys_handle: asyncio.Handle | None = None
 
         self._sys_interval: int = 0
+        self._sys_qos: int | None = None
         self._current_process = psutil.Process()
 
     def _clear_stats(self) -> None:
@@ -94,7 +96,7 @@ class BrokerSysPlugin(BasePlugin[BrokerContext]):
 
     async def _broadcast_sys_topic(self, topic_basename: str, data: bytes) -> None:
         """Broadcast a system topic."""
-        await self.context.broadcast_message(topic_basename, data)
+        await self.context.broadcast_message(topic_basename, data, self._sys_qos)
 
     def schedule_broadcast_sys_topic(self, topic_basename: str, data: bytes) -> asyncio.Task[None]:
         """Schedule broadcasting of system topics."""
@@ -115,6 +117,7 @@ class BrokerSysPlugin(BasePlugin[BrokerContext]):
 
         # Start $SYS topics management
         self._sys_interval = self._get_config_option("sys_interval", None)
+        self._sys_qos = self._get_config_option("qos", None)
 
         if not self._sys_interval:
             self.context.logger.warning("'sys_interval' key is not set or is None")
@@ -241,3 +244,11 @@ class BrokerSysPlugin(BasePlugin[BrokerContext]):
         """Configuration struct for plugin."""
 
         sys_interval: int = 20
+        """Interval in seconds between system topic updates."""
+        qos: int | None = None
+        """QoS level for system topic updates. Blank to inherit subscriber QoS. Otherwise: 0, 1 or 2 only."""
+
+        def __post_init__(self):
+            if self.qos is not None and (self.qos < 0 or self.qos > 2):
+                msg = "QoS level must be 0, 1 or 2."
+                raise PluginInitError(f"BrokerSysPlugin: {msg}")

--- a/amqtt/plugins/sys/broker.py
+++ b/amqtt/plugins/sys/broker.py
@@ -250,5 +250,5 @@ class BrokerSysPlugin(BasePlugin[BrokerContext]):
 
         def __post_init__(self) -> None:
             if self.qos is not None and (self.qos < 0 or self.qos > 2):
-                msg = "QoS level must be 0, 1 or 2."
-                raise PluginInitError(f"BrokerSysPlugin: {msg}")
+                msg = "BrokerSysPlugin: QoS level must be 0, 1 or 2."
+                raise PluginInitError(msg)

--- a/amqtt/plugins/sys/broker.py
+++ b/amqtt/plugins/sys/broker.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 from typing import Any, SupportsIndex, SupportsInt, TypeAlias  # pylint: disable=C0412
 
 import psutil
-from amqtt.errors import PluginInitError
 
+from amqtt.errors import PluginInitError
 from amqtt.plugins.base import BasePlugin
 from amqtt.session import Session
 
@@ -249,6 +249,7 @@ class BrokerSysPlugin(BasePlugin[BrokerContext]):
         """QoS level for system topic updates. Blank to inherit subscriber QoS. Otherwise: 0, 1 or 2 only."""
 
         def __post_init__(self) -> None:
+            """Check config for errors."""
             if self.qos is not None and (self.qos < 0 or self.qos > 2):
                 msg = "BrokerSysPlugin: QoS level must be 0, 1 or 2."
                 raise PluginInitError(msg)

--- a/tests/plugins/test_sys.py
+++ b/tests/plugins/test_sys.py
@@ -8,7 +8,8 @@ import pytest
 
 from amqtt.broker import Broker
 from amqtt.client import MQTTClient
-from amqtt.mqtt.constants import QOS_0
+from amqtt.errors import PluginInitError
+from amqtt.mqtt.constants import QOS_0, QOS_1, QOS_2
 from tests.asserts import does_not_warn
 
 dictConfig({
@@ -66,7 +67,11 @@ all_sys_topics = [
 ]
 
 
-async def _collect_expected_sys_topics(client: MQTTClient, sys_topic_flags: dict[str, bool]) -> int:
+async def _collect_expected_sys_topics(
+    client: MQTTClient,
+    sys_topic_flags: dict[str, bool],
+    expected_qos: int | None = None,
+) -> int:
     loop = asyncio.get_running_loop()
     deadline = loop.time() + 5
     sys_msg_count = 0
@@ -85,6 +90,8 @@ async def _collect_expected_sys_topics(client: MQTTClient, sys_topic_flags: dict
         if message and message.topic.startswith("$SYS/"):
             sys_msg_count += 1
             assert message.topic in sys_topic_flags
+            if expected_qos is not None:
+                assert message.qos == expected_qos
             sys_topic_flags[message.topic] = True
 
     return sys_msg_count
@@ -197,6 +204,69 @@ async def test_broker_sys_plugin_config() -> None:
 
     assert all(
         sys_topic_flags.values()), f'topic not received: {[topic for topic, flag in sys_topic_flags.items() if not flag]}'
+
+
+@pytest.mark.asyncio
+async def test_broker_sys_plugin_configured_qos_is_used_for_broadcasts() -> None:
+
+    sys_topic_flags = {
+        sys_topic: False
+        for sys_topic in all_sys_topics
+        if sys_topic != "$SYS/broker/version"
+    }
+
+    config = {
+        "listeners": {
+            "default": {"type": "tcp", "bind": "127.0.0.1:0", "max_connections": 10},
+        },
+        'plugins': [
+            {'amqtt.plugins.authentication.AnonymousAuthPlugin': {'allow_anonymous': True}},
+            {'amqtt.plugins.sys.broker.BrokerSysPlugin': {'sys_interval': 60, 'qos': QOS_1}},
+        ]
+    }
+
+    broker = Broker(plugin_namespace='tests.mock_plugins', config=config)
+    client = MQTTClient()
+    sys_msg_count = 0
+    try:
+        await broker.start()
+        await client.connect(_broker_uri(broker))
+        await client.subscribe([("$SYS/#", QOS_2), ])
+
+        retained_version = await client.deliver_message(timeout_duration=1)
+        assert retained_version is not None
+        assert retained_version.topic == "$SYS/broker/version"
+        assert retained_version.qos == QOS_2
+
+        _cancel_sys_broadcast(broker)
+        broker.plugins_manager.get_plugin('BrokerSysPlugin').broadcast_dollar_sys_topics()
+        sys_msg_count = await _collect_expected_sys_topics(client, sys_topic_flags, expected_qos=QOS_1)
+    finally:
+        _cancel_sys_broadcast(broker)
+        await _disconnect_client(client)
+        await _shutdown_broker(broker)
+
+    assert sys_msg_count > 1
+
+    assert all(
+        sys_topic_flags.values()), f'topic not received: {[topic for topic, flag in sys_topic_flags.items() if not flag]}'
+
+
+@pytest.mark.parametrize("qos", [-1, 3])
+@pytest.mark.asyncio
+async def test_broker_sys_plugin_invalid_qos_config(qos: int) -> None:
+
+    config = {
+        "listeners": {
+            "default": {"type": "tcp", "bind": "127.0.0.1:0", "max_connections": 10},
+        },
+        'plugins': [
+            {'amqtt.plugins.sys.broker.BrokerSysPlugin': {'qos': qos}},
+        ]
+    }
+
+    with pytest.raises(PluginInitError, match="QoS level must be 0, 1 or 2"):
+        _ = Broker(plugin_namespace='tests.mock_plugins', config=config)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Changes included in this PR

Adding config option for delivering $SYS messages at different QoS

### Current behavior

inherits QoS from subscriber connection

### New behavior

defaults to current behavior. can be set to QoS 0, 1 or 2.

### Impact

no breaking changes

### Checklist

1. [X] Does your submission pass the existing tests?
2. [X] Are there new tests that cover these additions/changes?
3. [X] Does this PR maintain or increase test coverage?
4. [X] Have you linted your code locally before submission?
