### PR TITLE
add ssl context to `ListenerConfig` API

### DIFF
--- a/amqtt/broker.py
+++ b/amqtt/broker.py
@@ -282,7 +282,11 @@ class Broker:
                 continue
 
             max_connections = listener.get("max_connections", -1)
-            ssl_context = self._create_ssl_context(listener) if listener.get("ssl", False) else None
+
+            ssl_context = listener.get("ssl_context", None) if listener.get("ssl", False) else None
+
+            if ssl_context is None:
+                ssl_context = self._create_ssl_context(listener) if listener.get("ssl", False) else None
 
             # for listeners which are external, don't need to create a server
             if listener.type == ListenerType.EXTERNAL:

--- a/amqtt/contexts.py
+++ b/amqtt/contexts.py
@@ -121,7 +121,7 @@ class ListenerConfig(Dictable):
     keyfile: str | Path | None = None
     """Full path to file in PEM format containing the server's private key."""
     ssl_context: SSLContext | None = None
-    """SSL context to use for the connection. Mutual exclusive with other ssl options. API only; not applicable to yaml-config."""
+    """SSL context to use for the connection. Mutually exclusive with other ssl options. API only; not applicable to yaml-config."""
     reader: str | None = None
     writer: str | None = None
 

--- a/amqtt/contexts.py
+++ b/amqtt/contexts.py
@@ -121,7 +121,8 @@ class ListenerConfig(Dictable):
     keyfile: str | Path | None = None
     """Full path to file in PEM format containing the server's private key."""
     ssl_context: SSLContext | None = None
-    """SSL context to use for the connection. Mutually exclusive with other ssl options. API only; not applicable to yaml-config."""
+    """SSL context to use for the connection. Mutually exclusive with other ssl options.
+     API only; not applicable to yaml-config."""
     reader: str | None = None
     writer: str | None = None
 

--- a/amqtt/contexts.py
+++ b/amqtt/contexts.py
@@ -121,7 +121,7 @@ class ListenerConfig(Dictable):
     keyfile: str | Path | None = None
     """Full path to file in PEM format containing the server's private key."""
     ssl_context: SSLContext | None = None
-    """SSL context to use for the connection. Mutual exclusive with other ssl options."""
+    """SSL context to use for the connection. Mutual exclusive with other ssl options. API only; not applicable to yaml-config."""
     reader: str | None = None
     writer: str | None = None
 

--- a/amqtt/contexts.py
+++ b/amqtt/contexts.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field, fields, replace
 import logging
+from ssl import SSLContext
 import warnings
 
 try:
@@ -22,6 +23,8 @@ if TYPE_CHECKING:
     import asyncio
 
 logger = logging.getLogger(__name__)
+_SSL_CONTEXT_EXCLUSIVE_FIELDS = ("cafile", "capath", "certfile", "keyfile", "cadata")
+_SSL_CONTEXT_PATH_FIELDS = ("cafile", "capath", "certfile", "keyfile")
 
 
 class BaseContext:
@@ -117,27 +120,46 @@ class ListenerConfig(Dictable):
     certificates needed to establish the certificate's authenticity.)"""
     keyfile: str | Path | None = None
     """Full path to file in PEM format containing the server's private key."""
+    ssl_context: SSLContext | None = None
+    """SSL context to use for the connection. Mutual exclusive with other ssl options."""
     reader: str | None = None
     writer: str | None = None
 
     def __post_init__(self) -> None:
         """Check config for errors and transform fields for easier use."""
+        self._validate()
+
+    def _validate(self) -> None:
+        """Validate listener configuration."""
+        if self.ssl_context is not None and any(getattr(self, fn) is not None for fn in _SSL_CONTEXT_EXCLUSIVE_FIELDS):
+            msg = "ListenerConfig: if specifying the 'ssl_context', other ssl options are not allowed."
+            raise ValueError(msg)
+
         if (self.certfile is None) ^ (self.keyfile is None):
             msg = "If specifying the 'certfile' or 'keyfile', both are required."
             raise ValueError(msg)
 
-        for fn in ("cafile", "capath", "certfile", "keyfile"):
+        for fn in _SSL_CONTEXT_PATH_FIELDS:
             if isinstance(getattr(self, fn), str):
                 setattr(self, fn, Path(getattr(self, fn)))
             if getattr(self, fn) and not getattr(self, fn).exists():
                 msg = f"'{fn}' does not exist : {getattr(self, fn)}"
                 raise FileNotFoundError(msg)
 
+        if self.ssl_context is not None and not self.ssl:
+            msg = "ListenerConfig: if specifying the 'ssl_context', 'ssl' must be True."
+            raise ValueError(msg)
+
     def apply(self, other: "ListenerConfig") -> None:
         """Apply the field from 'other', if 'self' field is default."""
         for f in fields(self):
+            if self.ssl_context is not None and f.name in _SSL_CONTEXT_EXCLUSIVE_FIELDS:
+                continue
+            if f.name == "ssl_context" and any(getattr(self, fn) is not None for fn in _SSL_CONTEXT_EXCLUSIVE_FIELDS):
+                continue
             if getattr(self, f.name) == f.default:
                 setattr(self, f.name, other[f.name])
+        self._validate()
 
 
 def default_listeners() -> dict[str, Any]:

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -3,6 +3,7 @@ import logging
 import logging.config
 import secrets
 import socket
+import ssl
 import string
 import time
 from unittest.mock import MagicMock, call, patch
@@ -14,6 +15,7 @@ from amqtt.events import BrokerEvents
 from amqtt.adapters import StreamReaderAdapter, StreamWriterAdapter
 from amqtt.broker import Broker
 from amqtt.client import MQTTClient
+from amqtt.contexts import BrokerConfig, ListenerConfig, ListenerType
 from amqtt.errors import ConnectError
 from amqtt.mqtt.connack import ConnackPacket
 from amqtt.mqtt.connect import ConnectPacket, ConnectPayload, ConnectVariableHeader
@@ -119,6 +121,51 @@ async def test_start_stop(broker, mock_plugin_manager):
         any_order=True,
     )
     assert broker.transitions.is_stopped()
+
+
+@pytest.mark.asyncio
+async def test_start_listeners_uses_supplied_ssl_context(monkeypatch):
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    broker = Broker(
+        BrokerConfig(
+            listeners={
+                "default": ListenerConfig(
+                    type=ListenerType.TCP,
+                    bind="127.0.0.1:0",
+                    ssl=True,
+                    ssl_context=ssl_context,
+                ),
+            },
+            plugins={},
+        ),
+    )
+    captured = {}
+
+    async def create_server_instance(listener_name, listener_type, address, port, server_ssl_context):
+        captured.update(
+            listener_name=listener_name,
+            listener_type=listener_type,
+            address=address,
+            port=port,
+            ssl_context=server_ssl_context,
+        )
+        return MagicMock()
+
+    def create_ssl_context(_listener):
+        raise AssertionError("Broker should use the listener's supplied SSLContext")
+
+    monkeypatch.setattr(broker, "_create_server_instance", create_server_instance)
+    monkeypatch.setattr(broker, "_create_ssl_context", create_ssl_context)
+
+    await broker._start_listeners()
+
+    assert captured == {
+        "listener_name": "default",
+        "listener_type": ListenerType.TCP,
+        "address": "127.0.0.1",
+        "port": 0,
+        "ssl_context": ssl_context,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_broker_config.py
+++ b/tests/test_broker_config.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+import ssl
 from typing import Any
 
 import pytest
@@ -17,6 +18,10 @@ from dacite import from_dict, Config
 from amqtt.contexts import BrokerConfig, ClientConfig, ConnectionConfig, ListenerConfig, ListenerType, TopicConfig, WillConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _ssl_context() -> ssl.SSLContext:
+    return ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
 
 
 def test_entrypoint_broker_config(caplog):
@@ -166,3 +171,68 @@ def test_client_config_rejects_mismatched_connection_cert_and_key() -> None:
 
     with pytest.raises(ValueError, match="both"):
         ClientConfig(connection=connection)
+
+def test_external_listener_accepts_default_fields() -> None:
+    broker_config = BrokerConfig.from_dict({"listeners": {"default": {"type": "external"}}})
+
+    assert broker_config.listeners["default"].type == ListenerType.EXTERNAL
+
+
+def test_ssl_context_with_false_ssl() -> None:
+    with pytest.raises(ValueError, match="'ssl' must be True"):
+        _ = ListenerConfig(ssl=False, ssl_context=_ssl_context())
+
+
+def test_ssl_context_with_other_ssl_config(tmp_path: Path) -> None:
+    cafile = tmp_path / "ca.pem"
+    cafile.write_text("ca", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="other ssl options are not allowed"):
+        _ = ListenerConfig(ssl=True, ssl_context=_ssl_context(), cafile=cafile)
+
+
+def test_ssl_context_for_broker_config() -> None:
+    context = _ssl_context()
+    broker_config = BrokerConfig.from_dict({"listeners": {"default": {"ssl": True, "ssl_context": context}}})
+
+    assert broker_config.listeners["default"].ssl_context is context
+
+
+def test_ssl_context_listener_does_not_inherit_default_certificate_paths(tmp_path: Path) -> None:
+    certfile = tmp_path / "cert.pem"
+    keyfile = tmp_path / "key.pem"
+    certfile.write_text("cert", encoding="utf-8")
+    keyfile.write_text("key", encoding="utf-8")
+    context = _ssl_context()
+
+    broker_config = BrokerConfig(
+        listeners={
+            "default": ListenerConfig(ssl=True, certfile=certfile, keyfile=keyfile),
+            "custom": ListenerConfig(bind="127.0.0.1:1884", ssl=True, ssl_context=context),
+        },
+    )
+
+    custom = broker_config.listeners["custom"]
+    assert custom.ssl_context is context
+    assert custom.certfile is None
+    assert custom.keyfile is None
+
+
+def test_certificate_path_listener_does_not_inherit_default_ssl_context(tmp_path: Path) -> None:
+    certfile = tmp_path / "cert.pem"
+    keyfile = tmp_path / "key.pem"
+    certfile.write_text("cert", encoding="utf-8")
+    keyfile.write_text("key", encoding="utf-8")
+    context = _ssl_context()
+
+    broker_config = BrokerConfig(
+        listeners={
+            "default": ListenerConfig(ssl=True, ssl_context=context),
+            "custom": ListenerConfig(bind="127.0.0.1:1884", ssl=True, certfile=certfile, keyfile=keyfile),
+        },
+    )
+
+    custom = broker_config.listeners["custom"]
+    assert custom.ssl_context is None
+    assert custom.certfile == certfile
+    assert custom.keyfile == keyfile


### PR DESCRIPTION
### Changes included in this PR

Instead of having to specify ssl config parameters as if they were being loaded from a config file, the `ListenerConfig` now accepts a full `SSLContext` as a parameter. 

### Current behavior

All parameters to `ListenerConfig` are specified to match the parameters in a config file.

### New behavior

SSL configuration options can use existing file-based fields _or_ provide an `SSLContext` instance.

### Impact

No breaking changes. 

### Checklist

1. [X] Does your submission pass the existing tests?
2. [X] Are there new tests that cover these additions/changes?
3. [X] Does this PR maintain or increase test coverage?
4. [X] Have you linted your code locally before submission?
